### PR TITLE
Feature/text tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,19 @@ endif()
 find_package(SDL2 REQUIRED)
 include_directories(${SDL2_INCLUDE_DIRS} ${SDL2_INCLUDE_DIRS}/SDL2)
 
+# SDL2_ttf (CMake config, vcpkg, or PkgConfig on Linux)
+set(KPEN_SDL2_TTF_TARGET "")
+find_package(SDL2_ttf QUIET CONFIG)
+if(TARGET SDL2_ttf::SDL2_ttf)
+    set(KPEN_SDL2_TTF_TARGET SDL2_ttf::SDL2_ttf)
+elseif(TARGET SDL2_ttf::SDL2_ttf-static)
+    set(KPEN_SDL2_TTF_TARGET SDL2_ttf::SDL2_ttf-static)
+else()
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(SDL2_TTF REQUIRED IMPORTED_TARGET SDL2_ttf)
+    set(KPEN_SDL2_TTF_TARGET PkgConfig::SDL2_TTF)
+endif()
+
 # Collect all .cc sources; add .mm only on Apple
 file(GLOB_RECURSE SRC_FILES "src/*.cc")
 
@@ -69,7 +82,12 @@ if(APPLE)
         MACOSX_BUNDLE TRUE
         MACOSX_BUNDLE_INFO_PLIST "${CMAKE_BINARY_DIR}/Info.plist"
     )
-    target_link_libraries(kPen SDL2::SDL2 "-framework AppKit")
+    target_link_libraries(kPen SDL2::SDL2 ${KPEN_SDL2_TTF_TARGET} "-framework AppKit")
+
+    get_target_property(KPEN_SDL2_TTF_DYLIB ${KPEN_SDL2_TTF_TARGET} IMPORTED_LOCATION)
+    if(NOT KPEN_SDL2_TTF_DYLIB)
+        get_target_property(KPEN_SDL2_TTF_DYLIB ${KPEN_SDL2_TTF_TARGET} IMPORTED_LOCATION_RELEASE)
+    endif()
 
     # Bundle SDL2 dylib so the .app is self-contained.
     # We copy the dylib into Frameworks/ and retarget the binary to load it from
@@ -91,6 +109,19 @@ if(APPLE)
             "$<TARGET_FILE:kPen>"
         COMMENT "Bundling SDL2 (${SDL2_DYLIB_NAME}) into kPen.app"
     )
+    if(KPEN_SDL2_TTF_DYLIB)
+        get_filename_component(SDL2_TTF_DYLIB_NAME "${KPEN_SDL2_TTF_DYLIB}" NAME)
+        add_custom_command(TARGET kPen POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                "${KPEN_SDL2_TTF_DYLIB}"
+                "$<TARGET_BUNDLE_DIR:kPen>/Contents/Frameworks/${SDL2_TTF_DYLIB_NAME}"
+            COMMAND install_name_tool -change
+                "${KPEN_SDL2_TTF_DYLIB}"
+                "@executable_path/../Frameworks/${SDL2_TTF_DYLIB_NAME}"
+                "$<TARGET_FILE:kPen>"
+            COMMENT "Bundling SDL2_ttf (${SDL2_TTF_DYLIB_NAME}) into kPen.app"
+        )
+    endif()
     # App icon
     if(EXISTS "${CMAKE_SOURCE_DIR}/assets/AppIcon.icns")
         add_custom_command(TARGET kPen POST_BUILD
@@ -109,10 +140,11 @@ else()
         target_link_libraries(kPen PRIVATE 
             $<TARGET_NAME_IF_EXISTS:SDL2::SDL2main>
             $<IF:$<TARGET_EXISTS:SDL2::SDL2>,SDL2::SDL2,SDL2::SDL2-static>
+            ${KPEN_SDL2_TTF_TARGET}
             winhttp
         )
     else()
-        target_link_libraries(kPen SDL2::SDL2)
+        target_link_libraries(kPen SDL2::SDL2 ${KPEN_SDL2_TTF_TARGET})
     endif()
 endif()
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ cmake --build build
 |               | Select (rectangle / lasso)       | `S`                         |
 |               | Fill                             | `F`                         |
 |               | Color pick                       | `I`                         |
-|               | Brush / text size down / up      | `,` / `.`                   |
+|               | Brush down / up                  | `,` / `.`                   |
 | **View**      | Pan hold / toggle                | `Space` / `H`               |
 |               | Reset zoom and pan               | `Cmd+0`                     |
 | **Selection** | Commit and deselect, or exit pan | `Escape`                    |

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ xattr -rd com.apple.quarantine /Applications/kPen.app
 
 **Linux (Experimental!)** — Download the latest `kPen` from [Releases](https://github.com/kaikino/kPen/releases) and run the `kPen` binary (`chmod +x kPen && ./kPen`).
 
-**Build from source** — Requires CMake 3.10+, C++17, and SDL2.
+**Build from source** — Requires CMake 3.10+, C++17, SDL2, and SDL2_ttf.
 
-- **macOS:** `brew install sdl2`. Output: `build/kPen.app`.
-- **Linux (Debian/Ubuntu):** `sudo apt install cmake libsdl2-dev`. Output: `build/kPen`.
-- **Linux (Fedora):** `sudo dnf install cmake SDL2-devel`. Output: `build/kPen`.
-- **Linux (Arch):** `sudo pacman -S cmake sdl2`. Output: `build/kPen`.
-- **Windows:** Install [CMake](https://cmake.org/download/) and [SDL2](https://github.com/libsdl-org/SDL/releases) (or vcpkg: `vcpkg install sdl2` and pass `-DCMAKE_TOOLCHAIN_FILE=[vcpkg]/scripts/buildsystems/vcpkg.cmake`). Output: `build/Release/kPen.exe`; put `SDL2.dll` next to it if using a prebuilt SDL2.
+- **macOS:** `brew install sdl2 sdl2_ttf`. Output: `build/kPen.app`.
+- **Linux (Debian/Ubuntu):** `sudo apt install cmake libsdl2-dev libsdl2-ttf-dev`. Output: `build/kPen`.
+- **Linux (Fedora):** `sudo dnf install cmake SDL2-devel SDL2_ttf-devel`. Output: `build/kPen`.
+- **Linux (Arch):** `sudo pacman -S cmake sdl2 sdl2_ttf`. Output: `build/kPen`.
+- **Windows:** Install [CMake](https://cmake.org/download/), [SDL2](https://github.com/libsdl-org/SDL/releases), and SDL2_ttf (or vcpkg: `vcpkg install sdl2 sdl2-ttf` and pass `-DCMAKE_TOOLCHAIN_FILE=[vcpkg]/scripts/buildsystems/vcpkg.cmake`). Output: `build/Release/kPen.exe`; place `SDL2.dll` and `SDL2_ttf.dll` next to the executable if using prebuilt libs.
 
 ```bash
 git clone https://github.com/kaikino/kPen.git
@@ -44,7 +44,7 @@ cmake --build build
 
 | Section            | Description                                                                                                                                                                                                                                       |
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Tool grid**      | 3×3 grid with 8 tools (Brush, Line, Eraser, Rect, Circle, Select, Fill, Pick). Click a tool to activate; click the same tool again to toggle its option (see Keybinds).                                                                           |
+| **Tool grid**      | 3×3 grid with 9 tools (Brush, Line, Eraser, Text, Rect, Circle, Select, Fill, Pick). Click a tool to activate; click the same tool again to toggle its option (see Keybinds).                                                                           |
 | **Brush size**     | Numeric field (1–99). Click to focus and type, or use `,` / `.` keys. Scroll wheel over the field to change size.                                                                                                                                 |
 | **Color wheel**    | Hue/saturation picker. Drag to set hue and saturation.                                                                                                                                                                                            |
 | **Color swatches** | 9 customizable colors and 27 preset colors. Arrow keys to navigate. Drag a swatch onto another to copy the source color into a custom swatch, or onto the canvas to set the background color. Select a color while a selection is active to fill. |
@@ -61,12 +61,13 @@ cmake --build build
 | **Tools**     | Brush (round / square)           | `B`                         |
 |               | Line                             | `L`                         |
 |               | Eraser (round / square)          | `E`                         |
+|               | Text                             | `T`                         |
 |               | Rect (outline / filled)          | `R`                         |
 |               | Circle (outline / filled)        | `O`                         |
 |               | Select (rectangle / lasso)       | `S`                         |
 |               | Fill                             | `F`                         |
 |               | Color pick                       | `I`                         |
-|               | Brush size down / up             | `,` / `.`                   |
+|               | Brush / text size down / up      | `,` / `.`                   |
 | **View**      | Pan hold / toggle                | `Space` / `H`               |
 |               | Reset zoom and pan               | `Cmd+0`                     |
 | **Selection** | Commit and deselect, or exit pan | `Escape`                    |

--- a/src/CursorManager.cc
+++ b/src/CursorManager.cc
@@ -755,25 +755,34 @@ void CursorManager::update(ICoordinateMapper* mapper,
     // Treat SELECT/RESIZE as "active" when mutating (resizing/rotating/moving) so we still show
     // the correct resize cursor with flip even when the mouse leaves the canvas during drag.
     bool toolActive = currentTool && currentTool->isActive();
-    if (!toolActive && currentTool && (currentType == ToolType::SELECT || currentType == ToolType::RESIZE)) {
+    if (!toolActive && currentTool && (currentType == ToolType::SELECT || currentType == ToolType::RESIZE ||
+                                      currentType == ToolType::TEXT)) {
         if (currentType == ToolType::SELECT) {
             SelectTool* st = static_cast<SelectTool*>(currentTool);
             if (st->isMutating()) toolActive = true;
         } else if (currentType == ToolType::RESIZE) {
             ResizeTool* rt = static_cast<ResizeTool*>(currentTool);
             if (rt->isMutating()) toolActive = true;
+        } else if (currentType == ToolType::TEXT) {
+            TextTool* tt = static_cast<TextTool*>(currentTool);
+            if (tt->isEditing() && tt->isMutating()) toolActive = true;
         }
     }
     // When outside canvas, still show handle cursor if over a selection/resize handle (handles are in window space, can be in letterbox)
     bool overTransformHandle = false;
-    if ((currentType == ToolType::SELECT || currentType == ToolType::RESIZE) && currentTool) {
+    if ((currentType == ToolType::SELECT || currentType == ToolType::RESIZE || currentType == ToolType::TEXT) &&
+        currentTool) {
         if (currentType == ToolType::SELECT) {
             SelectTool* st = static_cast<SelectTool*>(currentTool);
             if (st->isSelectionActive() && st->getHandleForCursor(0, 0) != TransformTool::Handle::NONE)
                 overTransformHandle = true;
-        } else {
+        } else if (currentType == ToolType::RESIZE) {
             ResizeTool* rt = static_cast<ResizeTool*>(currentTool);
             if (rt->getHandleForCursor(0, 0) != TransformTool::Handle::NONE)
+                overTransformHandle = true;
+        } else {
+            TextTool* tt = static_cast<TextTool*>(currentTool);
+            if (tt->isEditing() && tt->getHandleForCursor(0, 0) != TransformTool::Handle::NONE)
                 overTransformHandle = true;
         }
     }
@@ -836,9 +845,54 @@ void CursorManager::update(ICoordinateMapper* mapper,
             if (curPick) setCursor(curPick);
             break;
         }
-        case ToolType::TEXT:
-            if (curIbeam) setCursor(curIbeam);
+        case ToolType::TEXT: {
+            auto* tt = static_cast<TextTool*>(currentTool);
+            if (!tt) {
+                if (curIbeam) setCursor(curIbeam);
+                break;
+            }
+            if (tt->isActive()) {
+                setCursor(curCross);
+                break;
+            }
+            if (!tt->isEditing()) {
+                if (curIbeam) setCursor(curIbeam);
+                break;
+            }
+            float rot = tt->getRotation();
+            bool flipX = true;
+            bool flipY = true;
+            int cX, cY;
+            mapper->getCanvasCoords(mouseWinX, mouseWinY, &cX, &cY);
+            TransformTool::Handle h;
+            if (tt->isMutating()) {
+                TransformTool::Handle activeResize = tt->getResizingHandle();
+                if (activeResize != TransformTool::Handle::NONE) {
+                    h = activeResize;
+                } else {
+                    if (!dragHandleLocked) {
+                        dragHandleLocked = true;
+                        lockedHandle = tt->getHandleForCursor(cX, cY);
+                    }
+                    h = lockedHandle;
+                }
+            } else {
+                dragHandleLocked = false;
+                h = tt->getHandleForCursor(cX, cY);
+            }
+            if (h == TransformTool::Handle::ROTATE) {
+                buildRotateCursor(rot);
+                if (curRotate) setCursor(curRotate);
+                break;
+            }
+            SDL_Cursor* rc = getResizeCursor(h, rot, flipX, flipY);
+            if (rc) {
+                setCursor(rc);
+            } else {
+                setCursor(tt->isHit(cX, cY) ? curIbeam : curArrow);
+            }
             break;
+        }
         case ToolType::SELECT: {
             auto* st = static_cast<SelectTool*>(currentTool);
             if (!st || !st->isSelectionActive()) { setCursor(curCross); break; }

--- a/src/CursorManager.cc
+++ b/src/CursorManager.cc
@@ -654,6 +654,7 @@ CursorManager::CursorManager() {
 void CursorManager::init() {
     curArrow    = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_ARROW);
     curCross    = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_CROSSHAIR);
+    curIbeam    = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_IBEAM);
     curHand     = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_HAND);
     curSizeAll  = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_SIZEALL);
     curSizeNS   = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_SIZENS);
@@ -673,6 +674,7 @@ void CursorManager::init() {
 CursorManager::~CursorManager() {
     SDL_FreeCursor(curArrow);
     SDL_FreeCursor(curCross);
+    SDL_FreeCursor(curIbeam);
     SDL_FreeCursor(curHand);
     SDL_FreeCursor(curSizeAll);
     SDL_FreeCursor(curSizeNS);
@@ -834,6 +836,9 @@ void CursorManager::update(ICoordinateMapper* mapper,
             if (curPick) setCursor(curPick);
             break;
         }
+        case ToolType::TEXT:
+            if (curIbeam) setCursor(curIbeam);
+            break;
         case ToolType::SELECT: {
             auto* st = static_cast<SelectTool*>(currentTool);
             if (!st || !st->isSelectionActive()) { setCursor(curCross); break; }

--- a/src/CursorManager.h
+++ b/src/CursorManager.h
@@ -29,6 +29,7 @@ public:
 private:
     SDL_Cursor* curArrow    = nullptr;
     SDL_Cursor* curCross    = nullptr;
+    SDL_Cursor* curIbeam    = nullptr;
     SDL_Cursor* curHand     = nullptr;
     SDL_Cursor* curSizeAll  = nullptr;
     SDL_Cursor* curSizeNS   = nullptr;

--- a/src/FontCache.cc
+++ b/src/FontCache.cc
@@ -1,0 +1,43 @@
+#include "FontCache.h"
+#include <algorithm>
+#include <cstdio>
+
+// New keys are distinguished by path + pixel size + TTF style (no styling,
+// bold, italic, etc.)
+std::string FontCache::makeKey(const std::string& path, int px, int style) {
+    char buf[32];
+    snprintf(buf, sizeof(buf), "|%d|%d", px, style);
+    return path + buf;
+}
+
+FontCache::FontCache() = default;
+
+// SDL requires TTF_CloseFont when done
+FontCache::~FontCache() {
+    for (auto& kv : map_) {
+        if (kv.second.font) TTF_CloseFont(kv.second.font);
+    }
+}
+
+// Whatever unordered_map::begin() points to is evicted
+void FontCache::evictOneIfNeeded() {
+    if ((int)map_.size() < kMaxEntries) return;
+    auto it = map_.begin();
+    if (it->second.font) TTF_CloseFont(it->second.font);
+    map_.erase(it);
+}
+
+TTF_Font* FontCache::get(const std::string& path, int pixelHeight, int ttfStyleMask) {
+    if (path.empty()) return nullptr;
+    pixelHeight = std::max(6, std::min(256, pixelHeight));
+    std::string key = makeKey(path, pixelHeight, ttfStyleMask);
+    auto it = map_.find(key);
+    if (it != map_.end()) return it->second.font;
+
+    evictOneIfNeeded();
+    TTF_Font* f = TTF_OpenFont(path.c_str(), pixelHeight);
+    if (!f) return nullptr;
+    TTF_SetFontStyle(f, ttfStyleMask);
+    map_[key].font = f;
+    return f;
+}

--- a/src/FontCache.h
+++ b/src/FontCache.h
@@ -1,0 +1,34 @@
+#pragma once
+#include <SDL2/SDL_ttf.h>
+#include <string>
+#include <unordered_map>
+
+// FontCache is a helper around SDL2_ttf that keeps the underlying TTF_Font
+// struct open by keeping a handle to it, giving this handle out when kPen asks
+// for this font instead of calling TTF_OpenFont repeatedly. Manages the
+// lifetime and use of the TTF_Font resource.
+
+/** Open/cache TTF_Font by (path, pixel height, TTF style mask). */
+class FontCache {
+  public:
+    FontCache();
+    ~FontCache();
+    // Entry point to a TTF_Font*, passes out handle to existing font, or
+    // opens a path to a font and store it. Will evict an existing entry if cap
+    // is reached (kMaxEntries).
+    TTF_Font* get(const std::string& path, int pixelHeight, int ttfStyleMask);
+
+  private:
+    // Wrapper class enables flexibility to add metadata
+    struct Entry {
+        TTF_Font* font = nullptr;
+    };
+    // Stores handle -> opened font
+    std::unordered_map<std::string, Entry> map_;
+    // Build new key
+    static std::string makeKey(const std::string& path, int px, int style);
+    // Drop one entry before inserting into map at capacity
+    void evictOneIfNeeded();
+    // Max distinct fonts that can stay open at once
+    static constexpr int kMaxEntries = 48;
+};

--- a/src/FontRegistry.cc
+++ b/src/FontRegistry.cc
@@ -1,0 +1,94 @@
+#include "FontRegistry.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <filesystem>
+#include <set>
+#include <string>
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#endif
+
+namespace fs = std::filesystem;
+
+// Returns true if the file name ends with a font extension (.ttf/.otf).
+static bool endsWithFontExt(const std::string& name) {
+    auto dot = name.rfind('.');
+    if (dot == std::string::npos) return false;
+    std::string ext = name.substr(dot);
+    for (char& c : ext) c = (char)std::tolower((unsigned char)c);
+    return ext == ".ttf" || ext == ".otf";
+}
+
+// Recursively scans a directory for font files and adds them to the output set.
+// Parameters:
+// - root:      the directory to scan
+// - out:       the set of font paths
+// - count:     the number of font files found
+// - maxFiles:  the maximum number of font files to find
+// - maxDepth:  the maximum depth to scan
+// - depth:     the current depth of the scan
+static void scanDir(const fs::path& root, std::set<std::string>& out, int& count, int maxFiles, int maxDepth, int depth) {
+    if (count >= maxFiles || depth > maxDepth) return;
+    std::error_code ec;
+    if (!fs::exists(root, ec)) return;
+    fs::directory_options opts = fs::directory_options::skip_permission_denied;
+    // Robust directory iteration: skips permission-denied directories, tries
+    // to resolve paths (i.e., symlinks) to canonical absolute paths, prevents
+    // iterator from throwing an exception, iterates until maxDepth/maxFiles or
+    // end of directory is reached.
+    for (fs::directory_iterator it(root, opts, ec), end; it != end && count < maxFiles; it.increment(ec)) {
+        if (ec) { ec.clear(); continue; }
+        const fs::path& p = it->path();
+        if (it->is_directory(ec)) {
+            scanDir(p, out, count, maxFiles, maxDepth, depth + 1);
+        } else if (it->is_regular_file(ec) && endsWithFontExt(p.filename().string())) {
+            std::error_code ec2;
+            std::string canon = fs::weakly_canonical(p, ec2).string();
+            if (!ec2 && out.insert(canon).second) count++;
+        }
+    }
+}
+
+// Scans the system fonts and returns a list of font paths (.ttf/.otf files).
+// Parameters:
+// - extraDirs: a list of extra directories to scan
+// Returns:
+// - a list of font paths (.ttf/.otf files)
+std::vector<std::string> FontRegistry_scanSystemFonts(const std::vector<std::string>& extraDirs) {
+    std::set<std::string> uniq;
+    int count = 0;
+    const int kMaxFiles = 4000;
+    const int kMaxDepth = 6;
+
+    // First scan caller-provided extra directories.
+    for (const std::string& d : extraDirs) {
+        if (!d.empty()) scanDir(fs::path(d), uniq, count, kMaxFiles, kMaxDepth, 0);
+    }
+
+    // Then scan common system font directories, platform-dependent.
+    // Currently supported: macOS, Windows, Linux.
+#if defined(__APPLE__)
+    scanDir("/System/Library/Fonts", uniq, count, kMaxFiles, kMaxDepth, 0);
+    scanDir("/Library/Fonts", uniq, count, kMaxFiles, kMaxDepth, 0);
+    if (const char* home = std::getenv("HOME"))
+        scanDir(fs::path(home) / "Library/Fonts", uniq, count, kMaxFiles, kMaxDepth, 0);
+#elif defined(_WIN32)
+    if (const char* windir = std::getenv("WINDIR"))
+        scanDir(fs::path(windir) / "Fonts", uniq, count, kMaxFiles, 2, 0);
+#else
+    scanDir("/usr/share/fonts", uniq, count, kMaxFiles, kMaxDepth, 0);
+    scanDir("/usr/local/share/fonts", uniq, count, kMaxFiles, kMaxDepth, 0);
+    if (const char* home = std::getenv("HOME"))
+        scanDir(fs::path(home) / ".local/share/fonts", uniq, count, kMaxFiles, kMaxDepth, 0);
+#endif
+
+    std::vector<std::string> v(uniq.begin(), uniq.end());
+    std::sort(v.begin(), v.end());
+    return v;
+}

--- a/src/FontRegistry.h
+++ b/src/FontRegistry.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+// FontRegistry scans the system fonts and returns a list of font paths (.ttf/.otf files).
+
+std::vector<std::string> FontRegistry_scanSystemFonts(const std::vector<std::string>& extraDirs = {});

--- a/src/Toolbar.cc
+++ b/src/Toolbar.cc
@@ -55,8 +55,6 @@ int Toolbar::sliderSectionY() const {
     int ty = toolStartY() - scrollY;
     int brushRow = ty + 3 * (ICON_SIZE + ICON_GAP) + 2;
     int afterBrush = brushRow + BS_ROW1_H + BS_ROW_GAP;
-    if (currentType == ToolType::TEXT)
-        return afterBrush + TEXT_STYLE_ROW_H + BS_ROW_GAP;
     return afterBrush;
 }
 
@@ -641,63 +639,65 @@ void Toolbar::draw(bool handActive, int winW, int winH) {
     }
     int brushRowY = ty + 3*(ICON_SIZE+ICON_GAP) + 2;
 
-    SDL_Rect bsField = { TB_PAD, brushRowY, BS_FIELD_W, BS_ROW1_H };
-    brushSizeFieldRect = bsField;
-    bool bsFocused = brushSizeFocused;
-    SDL_SetRenderDrawColor(renderer, bsFocused ? 45 : 38, bsFocused ? 45 : 38, bsFocused ? 55 : 45, 255);
-    SDL_RenderFillRect(renderer, &bsField);
-    SDL_SetRenderDrawColor(renderer, bsFocused ? 70 : 55, bsFocused ? 130 : 55, bsFocused ? 220 : 62, 255);
-    SDL_RenderDrawRect(renderer, &bsField);
-    SDL_SetRenderDrawColor(renderer, 220, 220, 230, 255);
-    int bsLen = brushSizeBufLen();
-    int textW = bsLen * 8 - 2;
-    int textX = bsField.x + (bsField.w - textW) / 2;
-    int textY = bsField.y + (BS_ROW1_H - 10) / 2;
-    drawDigitString(textX, textY, brushSizeBuf, bsLen);
-    if (bsFocused) {
-        int curX = textX + bsLen * 8;
-        SDL_SetRenderDrawColor(renderer, 200, 200, 220, 255);
-        SDL_RenderDrawLine(renderer, curX, bsField.y + 2, curX, bsField.y + BS_ROW1_H - 3);
-    }
-
-    int previewAreaX = TB_PAD + BS_FIELD_W + BS_GAP;
-    int previewAreaW = contentWidth() - BS_FIELD_W - BS_GAP;
-    int previewCX = previewAreaX + previewAreaW / 2;
-    int previewCY = brushRowY + BS_ROW1_H / 2;
-    int maxR = BS_ROW1_H / 2 - 1;
-    int dotR = std::max(1, (int)((std::min(brushSize, 25) / 25.f) * maxR + 0.5f));
-    SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
-    bool previewSquare = (currentType == ToolType::BRUSH   && squareBrush) ||
-                         (currentType == ToolType::ERASER  && squareEraser);
-    if (previewSquare) {
-        SDL_Rect sq = { previewCX - dotR, previewCY - dotR, dotR * 2 + 1, dotR * 2 + 1 };
-        SDL_RenderFillRect(renderer, &sq);
+    int wTop;
+    if (currentType == ToolType::TEXT) {
+        brushSizeFieldRect = { 0, 0, 0, 0 };
+        drawTextToolStyleRow(brushRowY);
+        wTop = brushRowY + TEXT_STYLE_ROW_H + BS_ROW_GAP + 8;
     } else {
-        for (int py = -dotR; py <= dotR; py++)
-            for (int px = -dotR; px <= dotR; px++)
-                if (px*px + py*py <= dotR*dotR)
-                    SDL_RenderDrawPoint(renderer, previewCX+px, previewCY+py);
+        SDL_Rect bsField = { TB_PAD, brushRowY, BS_FIELD_W, BS_ROW1_H };
+        brushSizeFieldRect = bsField;
+        bool bsFocused = brushSizeFocused;
+        SDL_SetRenderDrawColor(renderer, bsFocused ? 45 : 38, bsFocused ? 45 : 38, bsFocused ? 55 : 45, 255);
+        SDL_RenderFillRect(renderer, &bsField);
+        SDL_SetRenderDrawColor(renderer, bsFocused ? 70 : 55, bsFocused ? 130 : 55, bsFocused ? 220 : 62, 255);
+        SDL_RenderDrawRect(renderer, &bsField);
+        SDL_SetRenderDrawColor(renderer, 220, 220, 230, 255);
+        int bsLen = brushSizeBufLen();
+        int textW = bsLen * 8 - 2;
+        int textX = bsField.x + (bsField.w - textW) / 2;
+        int textY = bsField.y + (BS_ROW1_H - 10) / 2;
+        drawDigitString(textX, textY, brushSizeBuf, bsLen);
+        if (bsFocused) {
+            int curX = textX + bsLen * 8;
+            SDL_SetRenderDrawColor(renderer, 200, 200, 220, 255);
+            SDL_RenderDrawLine(renderer, curX, bsField.y + 2, curX, bsField.y + BS_ROW1_H - 3);
+        }
+
+        int previewAreaX = TB_PAD + BS_FIELD_W + BS_GAP;
+        int previewAreaW = contentWidth() - BS_FIELD_W - BS_GAP;
+        int previewCX = previewAreaX + previewAreaW / 2;
+        int previewCY = brushRowY + BS_ROW1_H / 2;
+        int maxR = BS_ROW1_H / 2 - 1;
+        int dotR = std::max(1, (int)((std::min(brushSize, 25) / 25.f) * maxR + 0.5f));
+        SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+        bool previewSquare = (currentType == ToolType::BRUSH   && squareBrush) ||
+                             (currentType == ToolType::ERASER  && squareEraser);
+        if (previewSquare) {
+            SDL_Rect sq = { previewCX - dotR, previewCY - dotR, dotR * 2 + 1, dotR * 2 + 1 };
+            SDL_RenderFillRect(renderer, &sq);
+        } else {
+            for (int py = -dotR; py <= dotR; py++)
+                for (int px = -dotR; px <= dotR; px++)
+                    if (px*px + py*py <= dotR*dotR)
+                        SDL_RenderDrawPoint(renderer, previewCX+px, previewCY+py);
+        }
+
+        int sliderY = sliderSectionY();
+        int sX = TB_PAD, sW = contentWidth(), sH = BS_ROW2_H;
+        int trackY = sliderY + sH/2;
+        SDL_SetRenderDrawColor(renderer, 60, 60, 68, 255);
+        SDL_RenderDrawLine(renderer, sX, trackY,   sX+sW, trackY);
+        SDL_RenderDrawLine(renderer, sX, trackY+1, sX+sW, trackY+1);
+        int thumbX = sX + (int)((std::min(brushSize, 25)-1)/24.f * sW);
+        SDL_Rect thumb = {thumbX-5, sliderY, 10, sH};
+        SDL_SetRenderDrawColor(renderer, 200, 200, 210, 255);
+        SDL_RenderFillRect(renderer, &thumb);
+        SDL_SetRenderDrawColor(renderer, 120, 120, 130, 255);
+        SDL_RenderDrawRect(renderer, &thumb);
+
+        wTop = brushRowY + BS_ROW1_H + BS_ROW_GAP + BS_ROW2_H + 8;
     }
-
-    int textStyleY = brushRowY + BS_ROW1_H + BS_ROW_GAP;
-    if (currentType == ToolType::TEXT)
-        drawTextToolStyleRow(textStyleY);
-
-    // Row 2: full-width slider
-    int sliderY = sliderSectionY();
-    int sX = TB_PAD, sW = contentWidth(), sH = BS_ROW2_H;
-    int trackY = sliderY + sH/2;
-    SDL_SetRenderDrawColor(renderer, 60, 60, 68, 255);
-    SDL_RenderDrawLine(renderer, sX, trackY,   sX+sW, trackY);
-    SDL_RenderDrawLine(renderer, sX, trackY+1, sX+sW, trackY+1);
-    int thumbX = sX + (int)((std::min(brushSize, 25)-1)/24.f * sW);
-    SDL_Rect thumb = {thumbX-5, sliderY, 10, sH};
-    SDL_SetRenderDrawColor(renderer, 200, 200, 210, 255);
-    SDL_RenderFillRect(renderer, &thumb);
-    SDL_SetRenderDrawColor(renderer, 120, 120, 130, 255);
-    SDL_RenderDrawRect(renderer, &thumb);
-
-    int wTop = brushRowY + BS_ROW1_H + BS_ROW_GAP + BS_ROW2_H + 8;
     int availH = winH - wTop - TB_PAD;
     int wheelDiam = std::min(contentWidth(), availH - 20);
     if (wheelDiam < 10) return;
@@ -891,6 +891,16 @@ void Toolbar::notifyClickOutside() {
     }
 }
 
+void Toolbar::defocusBrushSizeField() {
+    if (!brushSizeFocused) return;
+    int v = 0;
+    for (int i = 0; i < brushSizeBufLen(); i++) v = v * 10 + (brushSizeBuf[i] - '0');
+    brushSize = std::max(1, std::min(99, v > 0 ? v : brushSize));
+    snprintf(brushSizeBuf, sizeof(brushSizeBuf), "%d", brushSize);
+    brushSizeFocused = false;
+    SDL_StopTextInput();
+}
+
 bool Toolbar::isInteractive(int x, int y) const {
     if (!inToolbar(x, y)) return false;
 
@@ -906,21 +916,20 @@ bool Toolbar::isInteractive(int x, int y) const {
         }
     }
 
-    SDL_Rect bsExp = { brushSizeFieldRect.x - 2, brushSizeFieldRect.y - 4,
-                       brushSizeFieldRect.w + 4, brushSizeFieldRect.h + 8 };
     SDL_Point winPt = { x, y };
-    if (SDL_PointInRect(&winPt, &bsExp)) return true;
-
-    if (currentType == ToolType::TEXT) {
+    if (currentType != ToolType::TEXT) {
+        SDL_Rect bsExp = { brushSizeFieldRect.x - 2, brushSizeFieldRect.y - 4,
+                           brushSizeFieldRect.w + 4, brushSizeFieldRect.h + 8 };
+        if (SDL_PointInRect(&winPt, &bsExp)) return true;
+        int sTop = sliderSectionY();
+        SDL_Rect sliderArea = { 0, sTop - 4, TB_W, sliderSectionH() + 8 };
+        if (SDL_PointInRect(&winPt, &sliderArea)) return true;
+    } else {
         if (SDL_PointInRect(&winPt, &textPrevRect) || SDL_PointInRect(&winPt, &textNextRect) ||
             SDL_PointInRect(&winPt, &textPtFieldRect) || SDL_PointInRect(&winPt, &textBoldRect) ||
             SDL_PointInRect(&winPt, &textItalicRect))
             return true;
     }
-
-    int sTop = sliderSectionY();
-    SDL_Rect sliderArea = { 0, sTop - 4, TB_W, sliderSectionH() + 8 };
-    if (SDL_PointInRect(&winPt, &sliderArea)) return true;
 
     // Color wheel
     float dx = x - colorWheelCX, dy2 = y - colorWheelCY;
@@ -960,7 +969,7 @@ bool Toolbar::onMouseDown(int x, int y) {
 
     int ty = toolStartY() - scrollY;
 
-    if (brushSizeFocused) {
+    if (brushSizeFocused && currentType != ToolType::TEXT) {
         SDL_Rect bsExp = { brushSizeFieldRect.x - 2, brushSizeFieldRect.y - 4,
                            brushSizeFieldRect.w + 4, brushSizeFieldRect.h + 8 };
         SDL_Point bsPt = { x, y };
@@ -1031,14 +1040,12 @@ bool Toolbar::onMouseDown(int x, int y) {
     if (hitTextToolStyleMouseDown(x, y))
         return true;
 
-    // Slider (row 2, full-width) + brush size field (row 1, left)
-    {
+    if (currentType != ToolType::TEXT) {
         int sTop = sliderSectionY();
         int sH = sliderSectionH();
-
         SDL_Rect sliderArea = { 0, sTop - 4, TB_W, sH + 8 };
         SDL_Point pt2 = { x, y };
-        
+
         if (SDL_PointInRect(&pt2, &sliderArea)) {
             if (brushSizeFocused) { brushSizeFocused = false; SDL_StopTextInput(); }
             if (textSizeFocused) {
@@ -1053,7 +1060,6 @@ bool Toolbar::onMouseDown(int x, int y) {
             updateSliderFromMouse(x);
             return true;
         }
-        // Brush size field (row 1, screen-space rect cached by draw())
         SDL_Rect bsExp = { brushSizeFieldRect.x - 2, brushSizeFieldRect.y - 4,
                            brushSizeFieldRect.w + 4, brushSizeFieldRect.h + 8 };
         if (SDL_PointInRect(&pt2, &bsExp)) {

--- a/src/Toolbar.cc
+++ b/src/Toolbar.cc
@@ -7,15 +7,15 @@
 #include <cstdio>
 #include <cstring>
 
-constexpr int toolGrid[3][3] = {{0,1,2},{3,-1,4},{5,6,7}};
+constexpr int toolGrid[3][3] = {{0,1,2},{3,8,4},{5,6,7}};
 constexpr ToolType toolTypes[] = {
     ToolType::BRUSH, ToolType::LINE, ToolType::ERASER,
     ToolType::RECT, ToolType::CIRCLE, ToolType::SELECT,
-    ToolType::FILL, ToolType::PICK
+    ToolType::FILL, ToolType::PICK, ToolType::TEXT
 };
 
 static const char* const toolNames[] = {
-    "Brush", "Line", "Eraser", "Rectangle", "Circle", "Select", "Fill", "Eyedropper"
+    "Brush", "Line", "Eraser", "Rectangle", "Circle", "Select", "Fill", "Eyedropper", "Text"
 };
 
 Toolbar::Toolbar(SDL_Renderer* renderer, kPen* app)
@@ -439,6 +439,12 @@ void Toolbar::drawIcon(int cx, int cy, ToolType t, bool active) {
             SDL_RenderDrawPoint(renderer, nx - 1, ny);
             SDL_RenderDrawPoint(renderer, nx - 1, ny + 1);
             SDL_RenderDrawPoint(renderer, nx - 2, ny + 2);
+            break;
+        }
+        case ToolType::TEXT: {
+            int topY = cy - 6;
+            SDL_RenderDrawLine(renderer, cx - 6, topY, cx + 6, topY);
+            SDL_RenderDrawLine(renderer, cx, topY, cx, cy + 6);
             break;
         }
         case ToolType::RESIZE:

--- a/src/Toolbar.cc
+++ b/src/Toolbar.cc
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cstdio>
 #include <cstring>
+#include <string>
 
 constexpr int toolGrid[3][3] = {{0,1,2},{3,8,4},{5,6,7}};
 constexpr ToolType toolTypes[] = {
@@ -18,10 +19,139 @@ static const char* const toolNames[] = {
     "Brush", "Line", "Eraser", "Rectangle", "Circle", "Select", "Fill", "Eyedropper", "Text"
 };
 
+static void drawTooltipString(SDL_Renderer* r, int x, int y, const char* s);
+
 Toolbar::Toolbar(SDL_Renderer* renderer, kPen* app)
     : renderer(renderer), app(app)
 {
     rgbToHsv(brushColor, hue, sat, val);
+    syncTextSizeBuf();
+}
+
+void Toolbar::setFontPathList(std::vector<std::string>* paths) {
+    fontPathList = paths;
+    clampTextFontIndex();
+}
+
+void Toolbar::clampTextFontIndex() {
+    if (!fontPathList || fontPathList->empty())
+        textFontIndex = 0;
+    else
+        textFontIndex = std::max(0, std::min(textFontIndex, (int)fontPathList->size() - 1));
+}
+
+std::string Toolbar::currentTextFontPath() const {
+    if (!fontPathList || fontPathList->empty()) return {};
+    if (textFontIndex < 0 || textFontIndex >= (int)fontPathList->size()) return {};
+    return (*fontPathList)[textFontIndex];
+}
+
+void Toolbar::syncTextSizeBuf() {
+    textFontPt = std::max(6, std::min(128, textFontPt));
+    snprintf(textSizeBuf, sizeof(textSizeBuf), "%d", textFontPt);
+}
+
+int Toolbar::sliderSectionY() const {
+    int ty = toolStartY() - scrollY;
+    int brushRow = ty + 3 * (ICON_SIZE + ICON_GAP) + 2;
+    int afterBrush = brushRow + BS_ROW1_H + BS_ROW_GAP;
+    if (currentType == ToolType::TEXT)
+        return afterBrush + TEXT_STYLE_ROW_H + BS_ROW_GAP;
+    return afterBrush;
+}
+
+void Toolbar::drawTextToolStyleRow(int rowY) {
+    const int h = 18;
+    const int gap = 1;
+    int x = TB_PAD;
+    const int wArrow = 11;
+    const int wPt = 20;
+    const int wBi = 11;
+    textPrevRect   = { x, rowY, wArrow, h }; x += wArrow + gap;
+    textNextRect   = { x, rowY, wArrow, h }; x += wArrow + gap;
+    textPtFieldRect = { x, rowY, wPt, h }; x += wPt + gap;
+    textBoldRect   = { x, rowY, wBi, h }; x += wBi + gap;
+    textItalicRect = { x, rowY, wBi, h };
+
+    auto fillBtn = [this](SDL_Rect r, bool active) {
+        SDL_SetRenderDrawColor(renderer, active ? 70 : 42, active ? 130 : 45, active ? 220 : 52, 255);
+        SDL_RenderFillRect(renderer, &r);
+        SDL_SetRenderDrawColor(renderer, 80, 80, 90, 255);
+        SDL_RenderDrawRect(renderer, &r);
+    };
+    fillBtn(textPrevRect, false);
+    fillBtn(textNextRect, false);
+    bool ptOn = textSizeFocused;
+    SDL_SetRenderDrawColor(renderer, ptOn ? 45 : 38, ptOn ? 45 : 38, ptOn ? 55 : 45, 255);
+    SDL_RenderFillRect(renderer, &textPtFieldRect);
+    SDL_SetRenderDrawColor(renderer, ptOn ? 70 : 55, ptOn ? 130 : 55, ptOn ? 220 : 62, 255);
+    SDL_RenderDrawRect(renderer, &textPtFieldRect);
+    fillBtn(textBoldRect, textBold);
+    fillBtn(textItalicRect, textItalic);
+
+    SDL_SetRenderDrawColor(renderer, 220, 220, 230, 255);
+    int cy = rowY + h / 2;
+    SDL_RenderDrawLine(renderer, textPrevRect.x + 8, cy - 3, textPrevRect.x + 3, cy);
+    SDL_RenderDrawLine(renderer, textPrevRect.x + 3, cy, textPrevRect.x + 8, cy + 3);
+    SDL_RenderDrawLine(renderer, textNextRect.x + 3, cy - 3, textNextRect.x + 8, cy);
+    SDL_RenderDrawLine(renderer, textNextRect.x + 8, cy, textNextRect.x + 3, cy + 3);
+
+    int tlen = textSizeFocused ? textSizeBufLen() : (int)std::strlen(textSizeBuf);
+    int tw = std::max(1, tlen) * 8 - 2;
+    int tx = textPtFieldRect.x + (textPtFieldRect.w - tw) / 2;
+    int ty = textPtFieldRect.y + (h - 10) / 2;
+    drawDigitString(tx, ty, textSizeBuf, tlen);
+    if (textSizeFocused) {
+        int curX = tx + tlen * 8;
+        SDL_SetRenderDrawColor(renderer, 200, 200, 220, 255);
+        SDL_RenderDrawLine(renderer, curX, textPtFieldRect.y + 2, curX, textPtFieldRect.y + h - 3);
+    }
+
+    SDL_SetRenderDrawColor(renderer, 230, 230, 245, 255);
+    drawTooltipString(renderer, textBoldRect.x + 2, textBoldRect.y + 4, "B");
+    drawTooltipString(renderer, textItalicRect.x + 2, textItalicRect.y + 4, "I");
+}
+
+bool Toolbar::hitTextToolStyleMouseDown(int mx, int my) {
+    if (currentType != ToolType::TEXT) return false;
+    SDL_Point p = { mx, my };
+    if (SDL_PointInRect(&p, &textPrevRect)) {
+        clampTextFontIndex();
+        if (fontPathList && !fontPathList->empty())
+            textFontIndex = (textFontIndex + (int)fontPathList->size() - 1) % (int)fontPathList->size();
+        return true;
+    }
+    if (SDL_PointInRect(&p, &textNextRect)) {
+        clampTextFontIndex();
+        if (fontPathList && !fontPathList->empty())
+            textFontIndex = (textFontIndex + 1) % (int)fontPathList->size();
+        return true;
+    }
+    if (SDL_PointInRect(&p, &textBoldRect)) {
+        textBold = !textBold;
+        return true;
+    }
+    if (SDL_PointInRect(&p, &textItalicRect)) {
+        textItalic = !textItalic;
+        return true;
+    }
+    if (SDL_PointInRect(&p, &textPtFieldRect)) {
+        if (brushSizeFocused) {
+            brushSizeFocused = false;
+            int v = 0;
+            for (int i = 0; i < brushSizeBufLen(); i++) v = v * 10 + (brushSizeBuf[i] - '0');
+            brushSize = std::max(1, std::min(99, v > 0 ? v : brushSize));
+            snprintf(brushSizeBuf, sizeof(brushSizeBuf), "%d", brushSize);
+            SDL_StopTextInput();
+        }
+        if (!textSizeFocused) {
+            textSizeFocused = true;
+            textSizeBuf[0] = 0;
+            SDL_StartTextInput();
+        }
+        return true;
+    }
+    return false;
 }
 
 void Toolbar::setMousePosition(int x, int y) {
@@ -226,6 +356,30 @@ void Toolbar::drawTooltip(int winW, int winH) {
     } else if (overScaleBtn) {
         hoverKey = 6000;
         label = resizeScaleMode ? "Crop Contents" : "Scale Contents";
+    } else if (currentType == ToolType::TEXT) {
+        SDL_Point ttp = { tooltipMouseX, tooltipMouseY };
+        if (SDL_PointInRect(&ttp, &textPrevRect)) {
+            hoverKey = 7101;
+            if (fontPathList && !fontPathList->empty())
+                snprintf(rgbBuf, sizeof(rgbBuf), "%d OF %d",
+                         textFontIndex + 1, (int)fontPathList->size());
+            label = (fontPathList && !fontPathList->empty()) ? rgbBuf : "NO FONTS";
+        } else if (SDL_PointInRect(&ttp, &textNextRect)) {
+            hoverKey = 7102;
+            if (fontPathList && !fontPathList->empty())
+                snprintf(rgbBuf, sizeof(rgbBuf), "%d OF %d",
+                         textFontIndex + 1, (int)fontPathList->size());
+            label = (fontPathList && !fontPathList->empty()) ? rgbBuf : "NO FONTS";
+        } else if (SDL_PointInRect(&ttp, &textPtFieldRect)) {
+            hoverKey = 7103;
+            label = "PT SIZE";
+        } else if (SDL_PointInRect(&ttp, &textBoldRect)) {
+            hoverKey = 7104;
+            label = "BOLD";
+        } else if (SDL_PointInRect(&ttp, &textItalicRect)) {
+            hoverKey = 7105;
+            label = "ITALIC";
+        }
     }
 
     if (hoverKey != tooltipHoveredIndex) {
@@ -525,8 +679,12 @@ void Toolbar::draw(bool handActive, int winW, int winH) {
                     SDL_RenderDrawPoint(renderer, previewCX+px, previewCY+py);
     }
 
+    int textStyleY = brushRowY + BS_ROW1_H + BS_ROW_GAP;
+    if (currentType == ToolType::TEXT)
+        drawTextToolStyleRow(textStyleY);
+
     // Row 2: full-width slider
-    int sliderY = brushRowY + BS_ROW1_H + BS_ROW_GAP;
+    int sliderY = sliderSectionY();
     int sX = TB_PAD, sW = contentWidth(), sH = BS_ROW2_H;
     int trackY = sliderY + sH/2;
     SDL_SetRenderDrawColor(renderer, 60, 60, 68, 255);
@@ -723,32 +881,46 @@ void Toolbar::notifyClickOutside() {
         brushSizeFocused = false;
         SDL_StopTextInput();
     }
+    if (textSizeFocused) {
+        int v = 0;
+        for (int i = 0; i < textSizeBufLen(); i++) v = v * 10 + (textSizeBuf[i] - '0');
+        textFontPt = std::max(6, std::min(128, v > 0 ? v : textFontPt));
+        syncTextSizeBuf();
+        textSizeFocused = false;
+        SDL_StopTextInput();
+    }
 }
 
 bool Toolbar::isInteractive(int x, int y) const {
     if (!inToolbar(x, y)) return false;
-    int sy = y + scrollY;
 
+    int ty = toolStartY() - scrollY;
     int cellW = toolCellW();
     for (int row = 0; row < 3; row++) {
         for (int col = 0; col < 3; col++) {
             int bx = TB_PAD/2 + col*cellW;
-            int by = toolStartY() + row*(ICON_SIZE+ICON_GAP);
+            int by = ty + row*(ICON_SIZE+ICON_GAP);
             SDL_Rect btn = {bx, by, cellW-2, ICON_SIZE};
-            SDL_Point pt = {x, sy};
+            SDL_Point pt = {x, y};
             if (SDL_PointInRect(&pt, &btn)) return true;
         }
     }
 
     SDL_Rect bsExp = { brushSizeFieldRect.x - 2, brushSizeFieldRect.y - 4,
                        brushSizeFieldRect.w + 4, brushSizeFieldRect.h + 8 };
-    SDL_Point bsPt = {x, y};
-    if (SDL_PointInRect(&bsPt, &bsExp)) return true;
+    SDL_Point winPt = { x, y };
+    if (SDL_PointInRect(&winPt, &bsExp)) return true;
+
+    if (currentType == ToolType::TEXT) {
+        if (SDL_PointInRect(&winPt, &textPrevRect) || SDL_PointInRect(&winPt, &textNextRect) ||
+            SDL_PointInRect(&winPt, &textPtFieldRect) || SDL_PointInRect(&winPt, &textBoldRect) ||
+            SDL_PointInRect(&winPt, &textItalicRect))
+            return true;
+    }
 
     int sTop = sliderSectionY();
     SDL_Rect sliderArea = { 0, sTop - 4, TB_W, sliderSectionH() + 8 };
-    SDL_Point sPt = {x, sy};
-    if (SDL_PointInRect(&sPt, &sliderArea)) return true;
+    if (SDL_PointInRect(&winPt, &sliderArea)) return true;
 
     // Color wheel
     float dx = x - colorWheelCX, dy2 = y - colorWheelCY;
@@ -757,7 +929,7 @@ bool Toolbar::isInteractive(int x, int y) const {
     // Brightness bar
     SDL_Rect bExp = {brightnessRect.x-2, brightnessRect.y-4,
                      brightnessRect.w+4, brightnessRect.h+8};
-    if (SDL_PointInRect(&bsPt, &bExp)) return true;
+    if (SDL_PointInRect(&winPt, &bExp)) return true;
 
     if (hitCustomSwatch(x, y) >= 0) return true;
     if (hitPresetSwatch(x, y) >= 0) return true;
@@ -786,7 +958,7 @@ bool Toolbar::onMouseDown(int x, int y) {
     if (!inToolbar(x, y)) return false;
     userScrolling = false;
 
-    int sy = y + scrollY;
+    int ty = toolStartY() - scrollY;
 
     if (brushSizeFocused) {
         SDL_Rect bsExp = { brushSizeFieldRect.x - 2, brushSizeFieldRect.y - 4,
@@ -798,6 +970,20 @@ bool Toolbar::onMouseDown(int x, int y) {
             brushSize = std::max(1, std::min(99, v > 0 ? v : brushSize));
             snprintf(brushSizeBuf, sizeof(brushSizeBuf), "%d", brushSize);
             brushSizeFocused = false;
+            SDL_StopTextInput();
+        }
+    }
+
+    if (textSizeFocused) {
+        SDL_Rect teExp = { textPtFieldRect.x - 2, textPtFieldRect.y - 4,
+                           textPtFieldRect.w + 4, textPtFieldRect.h + 8 };
+        SDL_Point tePt = { x, y };
+        if (!SDL_PointInRect(&tePt, &teExp)) {
+            int v = 0;
+            for (int i = 0; i < textSizeBufLen(); i++) v = v * 10 + (textSizeBuf[i] - '0');
+            textFontPt = std::max(6, std::min(128, v > 0 ? v : textFontPt));
+            syncTextSizeBuf();
+            textSizeFocused = false;
             SDL_StopTextInput();
         }
     }
@@ -820,9 +1006,9 @@ bool Toolbar::onMouseDown(int x, int y) {
             int idx = toolGrid[row][col];
             if (idx < 0) continue;
             int bx = TB_PAD/2 + col*cellW;
-            int by = toolStartY() + row*(ICON_SIZE+ICON_GAP);
+            int by = ty + row*(ICON_SIZE+ICON_GAP);
             SDL_Rect btn = {bx, by, cellW-2, ICON_SIZE};
-            SDL_Point pt = {x, sy};
+            SDL_Point pt = {x, y};
             if (SDL_PointInRect(&pt, &btn)) {
                 ToolType t = toolTypes[idx];
                 if (t == currentType && t == ToolType::RECT)
@@ -842,16 +1028,27 @@ bool Toolbar::onMouseDown(int x, int y) {
         }
     }
 
+    if (hitTextToolStyleMouseDown(x, y))
+        return true;
+
     // Slider (row 2, full-width) + brush size field (row 1, left)
     {
         int sTop = sliderSectionY();
         int sH = sliderSectionH();
 
         SDL_Rect sliderArea = { 0, sTop - 4, TB_W, sH + 8 };
-        SDL_Point pt2 = {x, sy};
+        SDL_Point pt2 = { x, y };
         
         if (SDL_PointInRect(&pt2, &sliderArea)) {
             if (brushSizeFocused) { brushSizeFocused = false; SDL_StopTextInput(); }
+            if (textSizeFocused) {
+                int v = 0;
+                for (int i = 0; i < textSizeBufLen(); i++) v = v * 10 + (textSizeBuf[i] - '0');
+                textFontPt = std::max(6, std::min(128, v > 0 ? v : textFontPt));
+                syncTextSizeBuf();
+                textSizeFocused = false;
+                SDL_StopTextInput();
+            }
             draggingSlider = true;
             updateSliderFromMouse(x);
             return true;
@@ -860,6 +1057,14 @@ bool Toolbar::onMouseDown(int x, int y) {
         SDL_Rect bsExp = { brushSizeFieldRect.x - 2, brushSizeFieldRect.y - 4,
                            brushSizeFieldRect.w + 4, brushSizeFieldRect.h + 8 };
         if (SDL_PointInRect(&pt2, &bsExp)) {
+            if (textSizeFocused) {
+                int v = 0;
+                for (int i = 0; i < textSizeBufLen(); i++) v = v * 10 + (textSizeBuf[i] - '0');
+                textFontPt = std::max(6, std::min(128, v > 0 ? v : textFontPt));
+                syncTextSizeBuf();
+                textSizeFocused = false;
+                SDL_StopTextInput();
+            }
             if (!brushSizeFocused) {
                 brushSizeFocused = true;
                 brushSizeBuf[0] = 0;
@@ -1369,6 +1574,16 @@ bool Toolbar::onTextInput(const char* text) {
         }
         return true;
     }
+    if (textSizeFocused) {
+        for (const char* c = text; *c; c++) {
+            int len = textSizeBufLen();
+            if (*c >= '0' && *c <= '9' && len < 3) {
+                textSizeBuf[len] = *c;
+                textSizeBuf[len + 1] = 0;
+            }
+        }
+        return true;
+    }
     if (resizeFocus == ResizeFocus::NONE) return false;
     char* buf = (resizeFocus == ResizeFocus::W) ? resizeWBuf : resizeHBuf;
     for (const char* c = text; *c; c++) {
@@ -1397,6 +1612,23 @@ bool Toolbar::onResizeKey(SDL_Keycode sym) {
             brushSize = std::max(1, std::min(99, v > 0 ? v : brushSize));
             snprintf(brushSizeBuf, sizeof(brushSizeBuf), "%d", brushSize);
             brushSizeFocused = false;
+            SDL_StopTextInput();
+            return true;
+        }
+        return false;
+    }
+    if (textSizeFocused) {
+        if (sym == SDLK_BACKSPACE) {
+            int len = textSizeBufLen();
+            if (len > 0) textSizeBuf[len - 1] = 0;
+            return true;
+        }
+        if (sym == SDLK_RETURN || sym == SDLK_KP_ENTER || sym == SDLK_ESCAPE || sym == SDLK_TAB) {
+            int v = 0;
+            for (int i = 0; i < textSizeBufLen(); i++) v = v * 10 + (textSizeBuf[i] - '0');
+            textFontPt = std::max(6, std::min(128, v > 0 ? v : textFontPt));
+            syncTextSizeBuf();
+            textSizeFocused = false;
             SDL_StopTextInput();
             return true;
         }

--- a/src/Toolbar.h
+++ b/src/Toolbar.h
@@ -4,6 +4,8 @@
 #include <cmath>
 #include <cstring>
 #include <algorithm>
+#include <string>
+#include <vector>
 #include "Tools.h"
 
 class kPen;
@@ -20,6 +22,8 @@ class Toolbar {
     static constexpr int BS_ROW1_H  = 20;
     static constexpr int BS_ROW2_H   = 14;
     static constexpr int BS_ROW_GAP  = 4;
+    /** Height of font/size/B/I row when Text tool is active (between brush row and size slider). */
+    static constexpr int TEXT_STYLE_ROW_H = 22;
 
     static constexpr int TRANSPARENT_PRESET_IDX = 0;
     static constexpr SDL_Color PRESETS[27] = {
@@ -43,6 +47,17 @@ class Toolbar {
     bool        squareBrush  = false;
     bool        squareEraser = false;
     bool        lassoSelect  = false;
+
+    /** System font paths (owned by kPen); null until kPen assigns after startup scan. */
+    std::vector<std::string>* fontPathList = nullptr;
+    int         textFontIndex = 0;
+    int         textFontPt    = 16;
+    bool        textBold      = false;
+    bool        textItalic    = false;
+    void        setFontPathList(std::vector<std::string>* paths);
+    std::string currentTextFontPath() const;
+    void        clampTextFontIndex();
+    bool        isTextSizeFieldFocused() const { return textSizeFocused; }
 
     SDL_Color   customColors[NUM_CUSTOM] = {
         {220,220,220,255},{180,180,180,255},{120,120,120,255},
@@ -114,6 +129,18 @@ class Toolbar {
     mutable SDL_Rect brushSizeFieldRect = {0, 0, 0, 0};
     int brushSizeBufLen() const { return (int)std::strlen(brushSizeBuf); }
 
+    bool textSizeFocused    = false;
+    char textSizeBuf[4]     = {'1', '6', 0, 0};
+    mutable SDL_Rect textPrevRect = {0, 0, 0, 0};
+    mutable SDL_Rect textNextRect = {0, 0, 0, 0};
+    mutable SDL_Rect textPtFieldRect = {0, 0, 0, 0};
+    mutable SDL_Rect textBoldRect = {0, 0, 0, 0};
+    mutable SDL_Rect textItalicRect = {0, 0, 0, 0};
+    int textSizeBufLen() const { return (int)std::strlen(textSizeBuf); }
+    void syncTextSizeBuf();
+    void drawTextToolStyleRow(int rowY);
+    bool hitTextToolStyleMouseDown(int mx, int my);
+
     int colorWheelCX = 0, colorWheelCY = 0, colorWheelR = 0;
     SDL_Rect brightnessRect = {0, 0, 0, 0};
     mutable int customGridY = 0;
@@ -149,7 +176,8 @@ class Toolbar {
     int toolStartY()      const { return TB_PAD; }
     static constexpr int toolCellW()    { return (TB_W - TB_PAD) / 3; }
     static constexpr int contentWidth() { return TB_W - TB_PAD*2; }
-    int sliderSectionY()  const { return toolStartY() + 3*(ICON_SIZE+ICON_GAP) + 2 + BS_ROW1_H + BS_ROW_GAP; }
+    /** Y (content coordinates) of the brush-size slider track for the current tool mode. */
+    int sliderSectionY()  const;
     int sliderSectionH()  const { return BS_ROW2_H; }
     int swatchCellSize()  const { return (contentWidth() - 4) / 3; }
     int swatchCellStride() const { return swatchCellSize() + 2; }

--- a/src/Toolbar.h
+++ b/src/Toolbar.h
@@ -107,6 +107,8 @@ class Toolbar {
     void syncCanvasSize(int w, int h);
     void syncBrushSize();
     void notifyClickOutside();
+    // Commit brush size field if focused (e.g. when switching to Text tool, which hides that field)
+    void defocusBrushSizeField();
     static SDL_Color hsvToRgb(float h, float s, float v);
     static void      rgbToHsv(SDL_Color c, float& h, float& s, float& v);
 

--- a/src/Tools.h
+++ b/src/Tools.h
@@ -7,6 +7,8 @@
 
 enum class ToolType { BRUSH, ERASER, LINE, RECT, CIRCLE, SELECT, FILL, PICK, TEXT, RESIZE, HAND };
 
+class kPen;
+
 class ICoordinateMapper {
   public:
     virtual void getCanvasCoords(int winX, int winY, int* canX, int* canY) = 0;
@@ -243,6 +245,7 @@ class ShapeTool : public AbstractTool {
 };
 
 class TextTool : public AbstractTool {
+    kPen*       pen_ = nullptr;
     std::string buffer;
     int         anchorX = 0, anchorY = 0;
     bool        editing_ = false;
@@ -251,9 +254,10 @@ class TextTool : public AbstractTool {
     std::function<void()> onAfterStamp;
     void        stopEditing();
     bool        stampToCanvas(SDL_Renderer* r);
-    static constexpr int kMaxChars = 256;
+    void        drawUtf8Line(SDL_Renderer* r, bool forOverlay);
+    static constexpr int kMaxBytes = 1024;
   public:
-    TextTool(ICoordinateMapper* m, std::function<void()> onAfterStamp);
+    TextTool(kPen* pen, std::function<void()> onAfterStamp);
     void onMouseDown(int cX, int cY, SDL_Renderer* r, int brushSize, SDL_Color color) override;
     bool onMouseUp  (int cX, int cY, SDL_Renderer* r, int brushSize, SDL_Color color) override;
     void onPreviewRender(SDL_Renderer* r, int brushSize, SDL_Color color) override;

--- a/src/Tools.h
+++ b/src/Tools.h
@@ -2,9 +2,10 @@
 
 #include <SDL2/SDL.h>
 #include <functional>
+#include <string>
 #include <vector>
 
-enum class ToolType { BRUSH, ERASER, LINE, RECT, CIRCLE, SELECT, FILL, PICK, RESIZE, HAND };
+enum class ToolType { BRUSH, ERASER, LINE, RECT, CIRCLE, SELECT, FILL, PICK, TEXT, RESIZE, HAND };
 
 class ICoordinateMapper {
   public:
@@ -239,6 +240,33 @@ class ShapeTool : public AbstractTool {
     bool isOverLineBody(int cX, int cY) const;
     /** Line endpoint canvas coords (only valid when isLineEditing()). */
     void getLineEndpoints(int& x0, int& y0, int& x1, int& y1) const;
+};
+
+class TextTool : public AbstractTool {
+    std::string buffer;
+    int         anchorX = 0, anchorY = 0;
+    bool        editing_ = false;
+    int         cachedBrushSize = 8;
+    SDL_Color   cachedColor     = {0, 0, 0, 255};
+    std::function<void()> onAfterStamp;
+    void        stopEditing();
+    bool        stampToCanvas(SDL_Renderer* r);
+    static constexpr int kMaxChars = 256;
+  public:
+    TextTool(ICoordinateMapper* m, std::function<void()> onAfterStamp);
+    void onMouseDown(int cX, int cY, SDL_Renderer* r, int brushSize, SDL_Color color) override;
+    bool onMouseUp  (int cX, int cY, SDL_Renderer* r, int brushSize, SDL_Color color) override;
+    void onPreviewRender(SDL_Renderer* r, int brushSize, SDL_Color color) override;
+    void onOverlayRender(SDL_Renderer* r) override;
+    bool hasOverlayContent() override { return editing_; }
+    void deactivate(SDL_Renderer* r) override;
+    bool isEditing() const { return editing_; }
+    void commitEdit(SDL_Renderer* r);
+    void discardEdit();
+    /** Returns true if any character was appended. */
+    bool onTextInput(const char* text);
+    /** Backspace/Delete while editing; returns true if consumed. */
+    bool onKeyDown(SDL_Keycode key);
 };
 
 class FillTool : public AbstractTool {

--- a/src/Tools.h
+++ b/src/Tools.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <SDL2/SDL.h>
+#include <SDL2/SDL_ttf.h>
 #include <functional>
 #include <string>
 #include <vector>
@@ -244,32 +245,43 @@ class ShapeTool : public AbstractTool {
     void getLineEndpoints(int& x0, int& y0, int& x1, int& y1) const;
 };
 
-class TextTool : public AbstractTool {
+/** Text placement: drag a box (or click for default size), type wrapped UTF-8, resize/rotate like ResizeTool. */
+class TextTool : public TransformTool {
     kPen*       pen_ = nullptr;
     std::string buffer;
-    int         anchorX = 0, anchorY = 0;
+    int         caretByte = 0;
     bool        editing_ = false;
     int         cachedBrushSize = 8;
     SDL_Color   cachedColor     = {0, 0, 0, 255};
     std::function<void()> onAfterStamp;
+
     void        stopEditing();
     bool        stampToCanvas(SDL_Renderer* r);
-    void        drawUtf8Line(SDL_Renderer* r, bool forOverlay);
+    void        renderTextOntoCanvas(SDL_Renderer* canvasRenderer, SDL_Color fg, bool forOverlay) const;
+    void        placeCaretFromCanvas(int cX, int cY);
+    void        beginEditingWithRect(SDL_Rect box);
+    void        clampBoundsToCanvas();
+    static void applyShiftSquare(int startX, int startY, int& curX, int& curY);
+    bool        buildLayoutLines(TTF_Font* font, int wrapPx, std::vector<std::pair<int, int>>& lines) const;
     static constexpr int kMaxBytes = 1024;
+    static constexpr int kPad = 4;
+    static constexpr int kDefaultBoxW = 200;
+    static constexpr int kDefaultBoxH = 100;
+    static constexpr int kMinBoxW = 24;
+    static constexpr int kMinBoxH = 24;
   public:
     TextTool(kPen* pen, std::function<void()> onAfterStamp);
     void onMouseDown(int cX, int cY, SDL_Renderer* r, int brushSize, SDL_Color color) override;
+    void onMouseMove(int cX, int cY, SDL_Renderer* r, int brushSize, SDL_Color color) override;
     bool onMouseUp  (int cX, int cY, SDL_Renderer* r, int brushSize, SDL_Color color) override;
     void onPreviewRender(SDL_Renderer* r, int brushSize, SDL_Color color) override;
     void onOverlayRender(SDL_Renderer* r) override;
-    bool hasOverlayContent() override { return editing_; }
+    bool hasOverlayContent() override { return isDrawing || editing_; }
     void deactivate(SDL_Renderer* r) override;
     bool isEditing() const { return editing_; }
     void commitEdit(SDL_Renderer* r);
     void discardEdit();
-    /** Returns true if any character was appended. */
     bool onTextInput(const char* text);
-    /** Backspace/Delete while editing; returns true if consumed. */
     bool onKeyDown(SDL_Keycode key);
 };
 

--- a/src/kPen.cc
+++ b/src/kPen.cc
@@ -213,6 +213,8 @@ template<typename F> void kPen::withCanvas(F f) {
 // Handles the tool switching logic.
 void kPen::setTool(ToolType t) {
     handToggledOn = false;  // clicking a tool or switching tool turns off hand
+    if (t == ToolType::TEXT)
+        toolbar.defocusBrushSizeField();
     if (currentTool) {
         withCanvas([&]{ currentTool->deactivate(renderer); });
         if (toolbar.currentType == ToolType::RESIZE) {
@@ -1071,10 +1073,16 @@ void kPen::handleKeyDown(SDL_Event& e, bool& running, bool& needsRedraw, bool& o
                 }
             } else if (toolbar.currentType == ToolType::TEXT && currentTool) {
                 auto* tt = static_cast<TextTool*>(currentTool.get());
+                // Plain Enter inserts a newline in the text box; Ctrl/Cmd+Enter commits.
                 if (tt->isEditing()) {
-                    withCanvas([&]{ tt->commitEdit(renderer); });
-                    needsRedraw = true;
-                    overlayDirty = true;
+                    if (e.key.keysym.mod & (KMOD_CTRL | KMOD_GUI)) {
+                        withCanvas([&]{ tt->commitEdit(renderer); });
+                        needsRedraw = true;
+                        overlayDirty = true;
+                    } else if (tt->onKeyDown(e.key.keysym.sym)) {
+                        needsRedraw = true;
+                        overlayDirty = true;
+                    }
                 }
             }
             break;
@@ -1620,6 +1628,10 @@ void kPen::handleMouseMotion(SDL_Event& e, bool& needsRedraw, bool& overlayDirty
     if (toolbar.currentType == ToolType::SELECT || toolbar.currentType == ToolType::RESIZE) {
         if (static_cast<TransformTool*>(currentTool.get())->isMutating())
             undoManager.clearRedo();
+    } else if (toolbar.currentType == ToolType::TEXT && currentTool) {
+        auto* tt = static_cast<TextTool*>(currentTool.get());
+        if (tt->isEditing() && tt->isMutating())
+            undoManager.clearRedo();
     }
 
     bool canvasPosChanged = (cX != lastMotionCX || cY != lastMotionCY);
@@ -1784,7 +1796,7 @@ void kPen::renderFrame(bool& overlayDirty) {
     currentTool->onPreviewRender(renderer, toolbar.brushSize, toolbar.brushColor);
     bool toolBusy = currentTool && (
         currentTool->isActive() ||
-        (toolbar.currentType == ToolType::TEXT && static_cast<TextTool*>(currentTool.get())->isEditing()) ||
+        (toolbar.currentType == ToolType::TEXT && currentTool->hasOverlayContent()) ||
         ((toolbar.currentType == ToolType::SELECT || toolbar.currentType == ToolType::RESIZE) &&
          static_cast<TransformTool*>(currentTool.get())->isMutating())
     );
@@ -1969,14 +1981,14 @@ void kPen::run() {
             }
         }
 
-        bool toolBusy = currentTool && (
+        bool toolBusyIdle = currentTool && (
             currentTool->isActive() ||
-            (toolbar.currentType == ToolType::TEXT && static_cast<TextTool*>(currentTool.get())->isEditing()) ||
+            (toolbar.currentType == ToolType::TEXT && currentTool->hasOverlayContent()) ||
             ((toolbar.currentType == ToolType::SELECT || toolbar.currentType == ToolType::RESIZE) &&
              static_cast<TransformTool*>(currentTool.get())->isMutating())
         );
 
-        if (toolBusy) {
+        if (toolBusyIdle) {
             Uint32 now = SDL_GetTicks();
             if (now - lastCursorUpdateTicks >= 33)
                 updateCursor(needsRedraw, overlayDirty), lastCursorUpdateTicks = now;

--- a/src/kPen.cc
+++ b/src/kPen.cc
@@ -1,8 +1,10 @@
 #define _USE_MATH_DEFINES
 #include "kPen.h"
+#include "FontRegistry.h"
 #include "DrawingUtils.h"
 #include "CanvasResizer.h"
 #include "ViewController.h"
+#include <SDL2/SDL_ttf.h>
 #include <cmath>
 #include <algorithm>
 #include <cstdio>
@@ -38,6 +40,21 @@ kPen::kPen() : toolbar(nullptr, this), canvasResizer(this) {
     WinMenu::install(window);  // native Windows menu bar (no-op on other platforms)
 
     toolbar = Toolbar(renderer, this);
+
+    // Initialization of SDL_ttf library
+    if (TTF_Init() != 0)
+        fprintf(stderr, "kPen: TTF_Init failed: %s\n", TTF_GetError());
+    {
+        // In FontRegistry, we will also scan the kPen application ditrectory
+        // for any other font files.
+        std::vector<std::string> extra;
+        if (char* base = SDL_GetBasePath()) {
+            extra.push_back(std::string(base) + "assets");
+            SDL_free(base);
+        }
+        systemFontPaths_ = FontRegistry_scanSystemFonts(extra);
+        toolbar.setFontPathList(&systemFontPaths_);
+    }
 
     canvas  = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_ARGB8888,
                                 SDL_TEXTUREACCESS_TARGET, canvasW, canvasH);
@@ -1107,15 +1124,25 @@ void kPen::handleKeyDown(SDL_Event& e, bool& running, bool& needsRedraw, bool& o
             if (hadSelectionOrResize) overlayDirty = true;
             break;
         }
+        // `.` and `,` increase and decrease brush size, respectively, while
+        // using the text tool. This is only done when the text tool is not
+        // focused (user hasn't clicked on canvas with text tool yet), so that
+        // these keys aren't stolen for brush adjustment while typing. When
+        // brush size is adjusted, a redraw is triggered, refreshing the
+        // overlay when the current tool uses it.
         case SDLK_COMMA:  // , = brush size down
-            toolbar.brushSize = std::max(1, toolbar.brushSize - 1);
-            toolbar.syncBrushSize();
+            if (!toolbar.isTextSizeFieldFocused()) {
+                toolbar.brushSize = std::max(1, toolbar.brushSize - 1);
+                toolbar.syncBrushSize();
+            }
             needsRedraw = true;
             if (currentTool->hasOverlayContent()) overlayDirty = true;
             break;
         case SDLK_PERIOD:  // . = brush size up
-            toolbar.brushSize = std::min(99, toolbar.brushSize + 1);
-            toolbar.syncBrushSize();
+            if (!toolbar.isTextSizeFieldFocused()) {
+                toolbar.brushSize = std::min(99, toolbar.brushSize + 1);
+                toolbar.syncBrushSize();
+            }
             needsRedraw = true;
             if (currentTool->hasOverlayContent()) overlayDirty = true;
             break;

--- a/src/kPen.cc
+++ b/src/kPen.cc
@@ -193,6 +193,7 @@ template<typename F> void kPen::withCanvas(F f) {
     SDL_SetRenderTarget(renderer, canvas); f(); SDL_SetRenderTarget(renderer, nullptr);
 }
 
+// Handles the tool switching logic.
 void kPen::setTool(ToolType t) {
     handToggledOn = false;  // clicking a tool or switching tool turns off hand
     if (currentTool) {
@@ -231,6 +232,9 @@ void kPen::setTool(ToolType t) {
             currentTool = std::make_unique<PickTool>(this, pickCb);
             break;
         }
+        case ToolType::TEXT:
+            currentTool = std::make_unique<TextTool>(this, [this]{ saveState(); });
+            break;
         case ToolType::RESIZE: break; // only created via activateResizeTool
         case ToolType::HAND: break;    // hand is space/handToggledOn only, no tool switch
     }
@@ -265,6 +269,10 @@ void kPen::saveState() {
 }
 
 void kPen::applyState(CanvasState& s) {
+    if (toolbar.currentType == ToolType::TEXT && currentTool) {
+        auto* tt = static_cast<TextTool*>(currentTool.get());
+        if (tt->isEditing()) tt->discardEdit();
+    }
     if (toolbar.currentType == ToolType::SELECT || toolbar.currentType == ToolType::RESIZE) {
         currentTool.reset(); // prevent setTool from deactivating+saving
         setTool(originalType);
@@ -312,6 +320,10 @@ void kPen::stampForRedo(AbstractTool* tool) {
 }
 
 void kPen::undo() {
+    if (toolbar.currentType == ToolType::TEXT && currentTool) {
+        auto* tt = static_cast<TextTool*>(currentTool.get());
+        if (tt->isEditing()) tt->discardEdit();
+    }
     if (toolbar.currentType == ToolType::SELECT) {
         auto* st = static_cast<SelectTool*>(currentTool.get());
         if (st->isSelectionActive()) {
@@ -490,6 +502,11 @@ void kPen::pasteFromClipboard() {
     if (w <= 0 || h <= 0 || pixels.empty()) return;
 
     // Commit any in-progress selection/resize before pasting
+    if (toolbar.currentType == ToolType::TEXT && currentTool) {
+        auto* tt = static_cast<TextTool*>(currentTool.get());
+        if (tt->isEditing())
+            withCanvas([&]{ tt->commitEdit(renderer); });
+    }
     if (toolbar.currentType == ToolType::SELECT) {
         auto* st = static_cast<SelectTool*>(currentTool.get());
         if (st->isSelectionActive()) {
@@ -794,6 +811,16 @@ void kPen::dispatchCommand(int code, bool& running, bool& needsRedraw, bool& ove
                     break;
                 }
             }
+            if (toolbar.currentType == ToolType::TEXT && currentTool) {
+                auto* tt = static_cast<TextTool*>(currentTool.get());
+                if (tt->isEditing()) {
+                    withCanvas([&]{ tt->commitEdit(renderer); });
+                    undo();
+                    needsRedraw = true;
+                    overlayDirty = true;
+                    break;
+                }
+            }
             undo();
             needsRedraw = true;
             break;
@@ -831,7 +858,7 @@ void kPen::dispatchCommand(int code, bool& running, bool& needsRedraw, bool& ove
 void kPen::processEvent(SDL_Event& e, bool& running, bool& needsRedraw, bool& overlayDirty) {
     if (e.type == SDL_QUIT) { handleQuit(running); return; }
     if (e.type == SDL_USEREVENT) { handleUserEvent(e, running, needsRedraw, overlayDirty); return; }
-    if (e.type == SDL_TEXTINPUT) { handleTextInput(e, needsRedraw); return; }
+    if (e.type == SDL_TEXTINPUT) { handleTextInput(e, needsRedraw, overlayDirty); return; }
     if (e.type == SDL_KEYDOWN) { handleKeyDown(e, running, needsRedraw, overlayDirty); return; }
     if (e.type == SDL_KEYUP) { handleKeyUp(e, needsRedraw); return; }
     if (e.type == SDL_WINDOWEVENT && e.window.event == SDL_WINDOWEVENT_RESIZED) { handleWindowEvent(e, needsRedraw); return; }
@@ -896,10 +923,19 @@ void kPen::handleUserEvent(SDL_Event& e, bool& running, bool& needsRedraw, bool&
     dispatchCommand(e.user.code, running, needsRedraw, overlayDirty);
 }
 
-void kPen::handleTextInput(SDL_Event& e, bool& needsRedraw) {
-    if (toolbar.onTextInput(e.text.text)) { needsRedraw = true; }
+// Handles text input events (typing in the text tool).
+void kPen::handleTextInput(SDL_Event& e, bool& needsRedraw, bool& overlayDirty) {
+    if (toolbar.onTextInput(e.text.text)) { needsRedraw = true; return; }
+    if (toolbar.currentType == ToolType::TEXT && currentTool) {
+        auto* tt = static_cast<TextTool*>(currentTool.get());
+        if (tt->onTextInput(e.text.text)) {
+            needsRedraw = true;
+            overlayDirty = true;
+        }
+    }
 }
 
+// Handles general key down (non-text input) events.
 void kPen::handleKeyDown(SDL_Event& e, bool& running, bool& needsRedraw, bool& overlayDirty) {
     // Track shift for aspect-lock override
     if (e.key.keysym.sym == SDLK_LSHIFT || e.key.keysym.sym == SDLK_RSHIFT) {
@@ -918,7 +954,7 @@ void kPen::handleKeyDown(SDL_Event& e, bool& running, bool& needsRedraw, bool& o
     if (handToggledOn && !(e.key.keysym.mod & (KMOD_GUI | KMOD_CTRL))) {
         switch (e.key.keysym.sym) {
             case SDLK_b: case SDLK_l: case SDLK_r: case SDLK_e: case SDLK_f: case SDLK_i:
-            case SDLK_s: case SDLK_o: case SDLK_h:
+            case SDLK_s: case SDLK_o: case SDLK_h: case SDLK_t:
             case SDLK_ESCAPE:
                 handToggledOn = false;
                 needsRedraw = true;
@@ -929,6 +965,22 @@ void kPen::handleKeyDown(SDL_Event& e, bool& running, bool& needsRedraw, bool& o
     }
     if (handKeyConsumed) return;
 
+    // While typing with the text tool, ignore single-key tool shortcuts so SDL_TEXTINPUT
+    // can append the character (KEYDOWN is usually delivered before TEXTINPUT).
+    if (toolbar.currentType == ToolType::TEXT && currentTool) {
+        auto* tt = static_cast<TextTool*>(currentTool.get());
+        if (tt->isEditing() && !(e.key.keysym.mod & (KMOD_GUI | KMOD_CTRL))) {
+            switch (e.key.keysym.sym) {
+                case SDLK_b: case SDLK_l: case SDLK_r: case SDLK_e: case SDLK_f: case SDLK_i:
+                case SDLK_s: case SDLK_o: case SDLK_t: case SDLK_h:
+                case SDLK_SPACE: case SDLK_COMMA: case SDLK_PERIOD:
+                    return;
+                default:
+                    break;
+            }
+        }
+    }
+
     switch (e.key.keysym.sym) {
         case SDLK_ESCAPE: {
             if (toolbar.currentType == ToolType::LINE && currentTool) {
@@ -936,6 +988,15 @@ void kPen::handleKeyDown(SDL_Event& e, bool& running, bool& needsRedraw, bool& o
                 if (shape->isLineEditing()) {
                     withCanvas([&]{ shape->commitLine(renderer); });
                     saveState();
+                    needsRedraw = true;
+                    overlayDirty = true;
+                    break;
+                }
+            }
+            if (toolbar.currentType == ToolType::TEXT && currentTool) {
+                auto* tt = static_cast<TextTool*>(currentTool.get());
+                if (tt->isEditing()) {
+                    tt->discardEdit();
                     needsRedraw = true;
                     overlayDirty = true;
                     break;
@@ -991,6 +1052,13 @@ void kPen::handleKeyDown(SDL_Event& e, bool& running, bool& needsRedraw, bool& o
                     needsRedraw = true;
                     overlayDirty = true;
                 }
+            } else if (toolbar.currentType == ToolType::TEXT && currentTool) {
+                auto* tt = static_cast<TextTool*>(currentTool.get());
+                if (tt->isEditing()) {
+                    withCanvas([&]{ tt->commitEdit(renderer); });
+                    needsRedraw = true;
+                    overlayDirty = true;
+                }
             }
             break;
         }
@@ -1006,6 +1074,7 @@ void kPen::handleKeyDown(SDL_Event& e, bool& running, bool& needsRedraw, bool& o
             setTool(ToolType::ERASER); needsRedraw = true; break;
         case SDLK_f: setTool(ToolType::FILL);   needsRedraw = true; break;
         case SDLK_i: setTool(ToolType::PICK);   needsRedraw = true; break;
+        case SDLK_t: setTool(ToolType::TEXT);   needsRedraw = true; break;
         case SDLK_h:
             if (!(e.key.keysym.mod & (KMOD_GUI | KMOD_CTRL))) {
                 handToggledOn = !handToggledOn;
@@ -1015,6 +1084,14 @@ void kPen::handleKeyDown(SDL_Event& e, bool& running, bool& needsRedraw, bool& o
         case SDLK_SPACE: spaceHeld = true; break;
         case SDLK_BACKSPACE:
         case SDLK_DELETE: {
+            if (toolbar.currentType == ToolType::TEXT && currentTool) {
+                auto* tt = static_cast<TextTool*>(currentTool.get());
+                if (tt->onKeyDown(e.key.keysym.sym)) {
+                    needsRedraw = true;
+                    overlayDirty = true;
+                    break;
+                }
+            }
             if (toolbar.currentType == ToolType::LINE && currentTool) {
                 auto* shape = static_cast<ShapeTool*>(currentTool.get());
                 if (shape->isLineEditing()) {
@@ -1046,6 +1123,10 @@ void kPen::handleKeyDown(SDL_Event& e, bool& running, bool& needsRedraw, bool& o
         case SDLK_RIGHT:
         case SDLK_UP:
         case SDLK_DOWN: {
+            if (toolbar.currentType == ToolType::TEXT && currentTool) {
+                auto* tt = static_cast<TextTool*>(currentTool.get());
+                if (tt->isEditing()) break;
+            }
             int dx = 0, dy = 0;
             if (e.key.keysym.sym == SDLK_LEFT)  dx = -1;
             if (e.key.keysym.sym == SDLK_RIGHT) dx =  1;
@@ -1400,6 +1481,13 @@ void kPen::handleMouseButtonDown(SDL_Event& e, bool& needsRedraw, bool& overlayD
             commitActiveTool();
             needsRedraw = true;
             overlayDirty = true;
+        } else if (toolbar.currentType == ToolType::TEXT && currentTool) {
+            auto* tt = static_cast<TextTool*>(currentTool.get());
+            if (tt->isEditing()) {
+                withCanvas([&]{ tt->commitEdit(renderer); });
+                needsRedraw = true;
+                overlayDirty = true;
+            }
         }
     }
     if (canvasResizer.onMouseDown(e.button.x, e.button.y, canvasW, canvasH)) {
@@ -1669,6 +1757,7 @@ void kPen::renderFrame(bool& overlayDirty) {
     currentTool->onPreviewRender(renderer, toolbar.brushSize, toolbar.brushColor);
     bool toolBusy = currentTool && (
         currentTool->isActive() ||
+        (toolbar.currentType == ToolType::TEXT && static_cast<TextTool*>(currentTool.get())->isEditing()) ||
         ((toolbar.currentType == ToolType::SELECT || toolbar.currentType == ToolType::RESIZE) &&
          static_cast<TransformTool*>(currentTool.get())->isMutating())
     );
@@ -1855,6 +1944,7 @@ void kPen::run() {
 
         bool toolBusy = currentTool && (
             currentTool->isActive() ||
+            (toolbar.currentType == ToolType::TEXT && static_cast<TextTool*>(currentTool.get())->isEditing()) ||
             ((toolbar.currentType == ToolType::SELECT || toolbar.currentType == ToolType::RESIZE) &&
              static_cast<TransformTool*>(currentTool.get())->isMutating())
         );
@@ -1890,6 +1980,20 @@ void kPen::run() {
                 (activeFingers > 0 || multiGestureActive || pinchActive ||
                  tapPending || twoFingerPivotSet || threeFingerPanMode)) {
                 resetGestureState();
+            }
+        }
+
+        if (toolbar.currentType == ToolType::TEXT && currentTool) {
+            auto* tt = static_cast<TextTool*>(currentTool.get());
+            if (tt->isEditing()) {
+                Uint32 now = SDL_GetTicks();
+                static Uint32 s_lastCaretPhase = 0;
+                Uint32 phase = now / 530;
+                if (phase != s_lastCaretPhase) {
+                    s_lastCaretPhase = phase;
+                    overlayDirty = true;
+                    needsRedraw = true;
+                }
             }
         }
 

--- a/src/kPen.h
+++ b/src/kPen.h
@@ -130,7 +130,7 @@ class kPen : public ICoordinateMapper {
     void processEvent(SDL_Event& e, bool& running, bool& needsRedraw, bool& overlayDirty);
     void handleQuit(bool& running);
     void handleUserEvent(SDL_Event& e, bool& running, bool& needsRedraw, bool& overlayDirty);
-    void handleTextInput(SDL_Event& e, bool& needsRedraw);
+    void handleTextInput(SDL_Event& e, bool& needsRedraw, bool& overlayDirty);
     void handleKeyDown(SDL_Event& e, bool& running, bool& needsRedraw, bool& overlayDirty);
     void handleKeyUp(SDL_Event& e, bool& needsRedraw);
     void handleWindowEvent(SDL_Event& e, bool& needsRedraw);

--- a/src/kPen.h
+++ b/src/kPen.h
@@ -3,6 +3,7 @@
 #include <vector>
 #include <memory>
 #include <string>
+#include "FontCache.h"
 #include "Tools.h"
 #include "Toolbar.h"
 #include "CanvasResizer.h"
@@ -10,6 +11,10 @@
 #include "UndoManager.h"
 #include "ViewController.h"
 #include "menu/MacMenu.h"
+
+
+// kPen is the main application object, being responsible for the window, 
+// renderer, drawing surface, and most runtime behavior.
 
 class kPen : public ICoordinateMapper {
   public:
@@ -23,6 +28,11 @@ class kPen : public ICoordinateMapper {
     void getWindowCoords(int canX, int canY, int* wX, int* wY) override;
     int  getWindowSize(int canSize) override;
     void getCanvasSize(int* w, int* h) override { *w = canvasW; *h = canvasH; }
+
+    // TextTool stores a kPen* and reads toolbar text state and font cache (see
+    // TextTool.cc (52:58)), which are private fields in kPen that TextTool
+    // needs access to, without widening kPen's public surface.
+    friend class TextTool;
 
     // Resize canvas; scaleContent=true stretches pixels, false crops/pads. originX/Y = top-left shift in canvas px (negative = grew up/left).
     // Returns false if new texture creation failed (canvas/overlay unchanged).
@@ -53,6 +63,19 @@ class kPen : public ICoordinateMapper {
 
     UndoManager undoManager;
     ViewController view_;
+
+    // Helper to ensure that the SDL_ttf library shuts down only after
+    // FontCache destroys its TTF_Font* handles.
+    struct TtfQuitHelper {
+        ~TtfQuitHelper() { TTF_Quit(); }
+    } ttfQuitAfterFonts_;
+
+    // Owns opened SDL_ttf font handles for the text tool. Opening these fonts
+    // is performed in FontCache
+    FontCache                fontCache_;
+    // List built at startup, stores paths to font files from the font
+    // registry scan performed in FontRegistry
+    std::vector<std::string> systemFontPaths_;
 
     void commitActiveTool();
     void resetViewAndGestureState();

--- a/src/tools/TextTool.cc
+++ b/src/tools/TextTool.cc
@@ -1,97 +1,23 @@
 #include "Tools.h"
+#include "kPen.h"
 #include <SDL2/SDL.h>
-#include <algorithm>
-#include <cstdint>
+#include <SDL2/SDL_ttf.h>
 
-// 5×7 bitmap font (matches toolbar tooltips). Index 0=space, 1–26=A–Z, 27–36=0–9, 37=comma.
-static const uint8_t FONT_5X7[38][7] = {
-    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 },
-    { 0x04, 0x0A, 0x11, 0x11, 0x1F, 0x11, 0x11 },
-    { 0x1E, 0x11, 0x11, 0x1E, 0x11, 0x11, 0x1E },
-    { 0x0E, 0x11, 0x10, 0x10, 0x10, 0x11, 0x0E },
-    { 0x1E, 0x11, 0x11, 0x11, 0x11, 0x11, 0x1E },
-    { 0x1F, 0x10, 0x10, 0x1E, 0x10, 0x10, 0x1F },
-    { 0x1F, 0x10, 0x10, 0x1E, 0x10, 0x10, 0x10 },
-    { 0x0E, 0x11, 0x10, 0x13, 0x11, 0x11, 0x0F },
-    { 0x11, 0x11, 0x11, 0x1F, 0x11, 0x11, 0x11 },
-    { 0x0E, 0x04, 0x04, 0x04, 0x04, 0x04, 0x0E },
-    { 0x01, 0x01, 0x01, 0x01, 0x11, 0x11, 0x0E },
-    { 0x11, 0x12, 0x14, 0x18, 0x14, 0x12, 0x11 },
-    { 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x1F },
-    { 0x11, 0x1B, 0x15, 0x11, 0x11, 0x11, 0x11 },
-    { 0x11, 0x19, 0x15, 0x13, 0x11, 0x11, 0x11 },
-    { 0x0E, 0x11, 0x11, 0x11, 0x11, 0x11, 0x0E },
-    { 0x1E, 0x11, 0x11, 0x1E, 0x10, 0x10, 0x10 },
-    { 0x0E, 0x11, 0x11, 0x11, 0x15, 0x12, 0x0D },
-    { 0x1E, 0x11, 0x11, 0x1E, 0x14, 0x12, 0x11 },
-    { 0x0F, 0x10, 0x10, 0x0E, 0x01, 0x11, 0x1E },
-    { 0x1F, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04 },
-    { 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x0E },
-    { 0x11, 0x11, 0x11, 0x0A, 0x0A, 0x04, 0x04 },
-    { 0x11, 0x11, 0x11, 0x15, 0x15, 0x1B, 0x11 },
-    { 0x11, 0x11, 0x0A, 0x04, 0x0A, 0x11, 0x11 },
-    { 0x11, 0x11, 0x0A, 0x04, 0x04, 0x04, 0x04 },
-    { 0x1F, 0x01, 0x02, 0x04, 0x08, 0x10, 0x1F },
-    { 0x1F, 0x11, 0x11, 0x11, 0x11, 0x11, 0x1F },
-    { 0x04, 0x0C, 0x04, 0x04, 0x04, 0x04, 0x1F },
-    { 0x1F, 0x01, 0x01, 0x1F, 0x10, 0x10, 0x1F },
-    { 0x1F, 0x01, 0x01, 0x0F, 0x01, 0x01, 0x1F },
-    { 0x11, 0x11, 0x11, 0x1F, 0x01, 0x01, 0x01 },
-    { 0x1F, 0x10, 0x10, 0x1F, 0x01, 0x01, 0x1F },
-    { 0x1F, 0x10, 0x10, 0x1F, 0x11, 0x11, 0x1F },
-    { 0x1F, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01 },
-    { 0x1F, 0x11, 0x11, 0x1F, 0x11, 0x11, 0x1F },
-    { 0x1F, 0x11, 0x11, 0x1F, 0x01, 0x01, 0x1F },
-    { 0x00, 0x00, 0x00, 0x00, 0x04, 0x04, 0x08 },
-};
+TextTool::TextTool(kPen* pen, std::function<void()> onAfterStamp)
+    : AbstractTool(pen), pen_(pen), onAfterStamp(std::move(onAfterStamp)) {}
 
-static int glyphIndex(char c) {
-    if (c == ' ') return 0;
-    if (c == '.' || c == ',') return 37;
-    if (c >= 'A' && c <= 'Z') return 1 + (c - 'A');
-    if (c >= '0' && c <= '9') return 27 + (c - '0');
-    return -1;
+static void utf8PopBack(std::string& s) {
+    if (s.empty()) return;
+    size_t i = s.size() - 1;
+    while (i > 0 && (static_cast<unsigned char>(s[i]) & 0xC0) == 0x80) --i;
+    s.resize(i);
 }
 
-static int textScaleForBrush(int brushSize) {
-    return std::max(1, std::min(6, brushSize / 2));
+static SDL_BlendMode eraseGlyphBlendMode() {
+    return SDL_ComposeCustomBlendMode(
+        SDL_BLENDFACTOR_ZERO, SDL_BLENDFACTOR_ONE_MINUS_SRC_ALPHA, SDL_BLENDOPERATION_ADD,
+        SDL_BLENDFACTOR_ZERO, SDL_BLENDFACTOR_ONE_MINUS_SRC_ALPHA, SDL_BLENDOPERATION_ADD);
 }
-
-static int glyphAdvance(int scale) { return 5 * scale + scale; }
-
-static int stringWidthPx(const std::string& s, int scale) {
-    int adv = glyphAdvance(scale);
-    int w = 0;
-    for (char c : s) {
-        if (glyphIndex(c) >= 0) w += adv;
-    }
-    return w;
-}
-
-static void drawGlyphPixels(SDL_Renderer* r, int ox, int oy, int gi,
-                            int scale, SDL_Color col) {
-    if (gi < 0 || gi > 37) return;
-    if (col.a == 0) {
-        SDL_SetRenderDrawBlendMode(r, SDL_BLENDMODE_NONE);
-        SDL_SetRenderDrawColor(r, 0, 0, 0, 0);
-    } else {
-        SDL_SetRenderDrawBlendMode(r, SDL_BLENDMODE_BLEND);
-        SDL_SetRenderDrawColor(r, col.r, col.g, col.b, col.a);
-    }
-    for (int row = 0; row < 7; row++) {
-        uint8_t bits = FONT_5X7[gi][row];
-        for (int gx = 0; gx < 5; gx++) {
-            if (bits & (1 << (4 - gx))) {
-                SDL_Rect rect = { ox + gx * scale, oy + row * scale, scale, scale };
-                SDL_RenderFillRect(r, &rect);
-            }
-        }
-    }
-    if (col.a == 0) SDL_SetRenderDrawBlendMode(r, SDL_BLENDMODE_BLEND);
-}
-
-TextTool::TextTool(ICoordinateMapper* m, std::function<void()> onAfterStamp)
-    : AbstractTool(m), onAfterStamp(std::move(onAfterStamp)) {}
 
 void TextTool::stopEditing() {
     if (!editing_) return;
@@ -120,41 +46,86 @@ void TextTool::onPreviewRender(SDL_Renderer*, int brushSize, SDL_Color color) {
     cachedColor = color;
 }
 
-void TextTool::onOverlayRender(SDL_Renderer* r) {
-    if (!editing_) return;
-    int scale = textScaleForBrush(cachedBrushSize);
-    int x = anchorX;
-    SDL_Color col = cachedColor;
-    for (char ch : buffer) {
-        int gi = glyphIndex(ch);
-        if (gi < 0) continue;
-        drawGlyphPixels(r, x, anchorY, gi, scale, col);
-        x += glyphAdvance(scale);
+void TextTool::drawUtf8Line(SDL_Renderer* r, bool forOverlay) {
+    if (!pen_ || buffer.empty()) return;
+
+    std::string path = pen_->toolbar.currentTextFontPath();
+    int pt = pen_->toolbar.textFontPt;
+    int style = TTF_STYLE_NORMAL;
+    if (pen_->toolbar.textBold) style |= TTF_STYLE_BOLD;
+    if (pen_->toolbar.textItalic) style |= TTF_STYLE_ITALIC;
+
+    TTF_Font* font = pen_->fontCache_.get(path, pt, style);
+    if (!font) return;
+
+    SDL_Color fg = cachedColor;
+    if (forOverlay && fg.a == 0)
+        fg = { 100, 149, 237, 255 };
+    else if (!forOverlay && fg.a != 0)
+        fg.a = 255;
+
+    SDL_Surface* surf = nullptr;
+    if (forOverlay || cachedColor.a != 0)
+        surf = TTF_RenderUTF8_Blended(font, buffer.c_str(), fg);
+    else
+        surf = TTF_RenderUTF8_Blended(font, buffer.c_str(), SDL_Color{ 255, 255, 255, 255 });
+
+    if (!surf) return;
+    SDL_Texture* tex = SDL_CreateTextureFromSurface(r, surf);
+    SDL_FreeSurface(surf);
+    if (!tex) return;
+
+    if (!forOverlay && cachedColor.a == 0) {
+        SDL_BlendMode eraseBm = eraseGlyphBlendMode();
+        if (SDL_SetTextureBlendMode(tex, eraseBm) != 0)
+            SDL_SetTextureBlendMode(tex, SDL_BLENDMODE_BLEND);
+    } else {
+        SDL_SetTextureBlendMode(tex, SDL_BLENDMODE_BLEND);
     }
+
+    int tw = 0, th = 0;
+    SDL_QueryTexture(tex, nullptr, nullptr, &tw, &th);
+    SDL_Rect dst{ anchorX, anchorY, tw, th };
+    SDL_RenderCopy(r, tex, nullptr, &dst);
+    SDL_DestroyTexture(tex);
+}
+
+void TextTool::onOverlayRender(SDL_Renderer* r) {
+    if (!editing_ || !pen_) return;
+    drawUtf8Line(r, true);
+
+    std::string path = pen_->toolbar.currentTextFontPath();
+    int pt = pen_->toolbar.textFontPt;
+    int style = TTF_STYLE_NORMAL;
+    if (pen_->toolbar.textBold) style |= TTF_STYLE_BOLD;
+    if (pen_->toolbar.textItalic) style |= TTF_STYLE_ITALIC;
+    TTF_Font* font = pen_->fontCache_.get(path, pt, style);
+
+    int caretX = anchorX;
+    int caretH = font ? TTF_FontHeight(font) : 14;
+    if (font && !buffer.empty()) {
+        int w = 0;
+        if (TTF_SizeUTF8(font, buffer.c_str(), &w, nullptr) == 0)
+            caretX += w;
+    }
+
     bool blinkOn = ((SDL_GetTicks() / 530) % 2) == 0;
     if (blinkOn) {
-        int caretx = anchorX + stringWidthPx(buffer, scale);
         SDL_SetRenderDrawBlendMode(r, SDL_BLENDMODE_BLEND);
+        SDL_Color col = cachedColor;
         if (col.a == 0)
             SDL_SetRenderDrawColor(r, 100, 149, 237, 200);
         else
             SDL_SetRenderDrawColor(r, col.r, col.g, col.b, 255);
-        int ch = 7 * scale;
-        SDL_Rect caret = { caretx, anchorY, std::max(1, scale), ch };
+        int cw = std::max(1, pt / 12);
+        SDL_Rect caret{ caretX, anchorY, cw, std::max(1, caretH) };
         SDL_RenderFillRect(r, &caret);
     }
 }
 
 bool TextTool::stampToCanvas(SDL_Renderer* r) {
     if (buffer.empty()) return false;
-    int scale = textScaleForBrush(cachedBrushSize);
-    int x = anchorX;
-    for (char ch : buffer) {
-        int gi = glyphIndex(ch);
-        if (gi < 0) continue;
-        drawGlyphPixels(r, x, anchorY, gi, scale, cachedColor);
-        x += glyphAdvance(scale);
-    }
+    drawUtf8Line(r, false);
     return true;
 }
 
@@ -178,14 +149,24 @@ void TextTool::deactivate(SDL_Renderer* r) {
 bool TextTool::onTextInput(const char* text) {
     if (!editing_ || !text) return false;
     bool any = false;
-    for (const unsigned char* p = reinterpret_cast<const unsigned char*>(text); *p; ++p) {
+    for (const unsigned char* p = reinterpret_cast<const unsigned char*>(text); *p;) {
         unsigned char c = *p;
-        if (c < 32 || c > 126) continue;
-        char ch = static_cast<char>(c);
-        if (ch >= 'a' && ch <= 'z') ch = static_cast<char>(ch - 'a' + 'A');
-        if (glyphIndex(ch) < 0) continue;
-        if ((int)buffer.size() >= kMaxChars) break;
-        buffer.push_back(ch);
+        if (c < 32 && c != '\t') {
+            ++p;
+            continue;
+        }
+        size_t runeLen = 1;
+        if (c >= 0xF0)
+            runeLen = 4;
+        else if (c >= 0xE0)
+            runeLen = 3;
+        else if (c >= 0xC0)
+            runeLen = 2;
+
+        if ((int)buffer.size() + (int)runeLen > kMaxBytes) break;
+        for (size_t i = 0; i < runeLen && p[i]; i++)
+            buffer.push_back(static_cast<char>(p[i]));
+        p += runeLen;
         any = true;
     }
     return any;
@@ -194,7 +175,7 @@ bool TextTool::onTextInput(const char* text) {
 bool TextTool::onKeyDown(SDL_Keycode key) {
     if (!editing_) return false;
     if (key == SDLK_BACKSPACE || key == SDLK_DELETE) {
-        if (!buffer.empty()) buffer.pop_back();
+        utf8PopBack(buffer);
         return true;
     }
     return false;

--- a/src/tools/TextTool.cc
+++ b/src/tools/TextTool.cc
@@ -1,10 +1,15 @@
 #include "Tools.h"
 #include "kPen.h"
+#include "DrawingUtils.h"
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_ttf.h>
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <vector>
 
 TextTool::TextTool(kPen* pen, std::function<void()> onAfterStamp)
-    : AbstractTool(pen), pen_(pen), onAfterStamp(std::move(onAfterStamp)) {}
+    : TransformTool(pen), pen_(pen), onAfterStamp(std::move(onAfterStamp)) {}
 
 static void utf8PopBack(std::string& s) {
     if (s.empty()) return;
@@ -13,86 +18,204 @@ static void utf8PopBack(std::string& s) {
     s.resize(i);
 }
 
+static int utf8CharBytes(const char* p) {
+    auto c = static_cast<unsigned char>(*p);
+    if (c >= 0xF0) return 4;
+    if (c >= 0xE0) return 3;
+    if (c >= 0xC0) return 2;
+    return 1;
+}
+
 static SDL_BlendMode eraseGlyphBlendMode() {
     return SDL_ComposeCustomBlendMode(
         SDL_BLENDFACTOR_ZERO, SDL_BLENDFACTOR_ONE_MINUS_SRC_ALPHA, SDL_BLENDOPERATION_ADD,
         SDL_BLENDFACTOR_ZERO, SDL_BLENDFACTOR_ONE_MINUS_SRC_ALPHA, SDL_BLENDOPERATION_ADD);
 }
 
-void TextTool::stopEditing() {
-    if (!editing_) return;
-    editing_ = false;
-    SDL_StopTextInput();
+/** When dragging a new text box with Shift held, keep width and height equal (same rule as unfilled rectangle). */
+void TextTool::applyShiftSquare(int startX, int startY, int& curX, int& curY) {
+    int dx = curX - startX, dy = curY - startY;
+    if (dx == 0 && dy == 0) return;
+    int adx = std::abs(dx), ady = std::abs(dy);
+    int d = std::min(adx, ady);
+    curX = startX + (dx >= 0 ? d : -d);
+    curY = startY + (dy >= 0 ? d : -d);
 }
 
-void TextTool::onMouseDown(int cX, int cY, SDL_Renderer* r, int brushSize, SDL_Color color) {
-    if (!isPointOnCanvas(mapper, cX, cY)) return;
-    cachedBrushSize = brushSize;
-    cachedColor = color;
-    if (editing_) commitEdit(r);
-    anchorX = cX;
-    anchorY = cY;
-    buffer.clear();
+void TextTool::clampBoundsToCanvas() {
+    int cw, ch;
+    mapper->getCanvasSize(&cw, &ch);
+    if (currentBounds.x < 0) {
+        currentBounds.w += currentBounds.x;
+        currentBounds.x = 0;
+    }
+    if (currentBounds.y < 0) {
+        currentBounds.h += currentBounds.y;
+        currentBounds.y = 0;
+    }
+    currentBounds.w = std::max(kMinBoxW, currentBounds.w);
+    currentBounds.h = std::max(kMinBoxH, currentBounds.h);
+    if (currentBounds.x + currentBounds.w > cw)
+        currentBounds.w = std::max(kMinBoxW, cw - currentBounds.x);
+    if (currentBounds.y + currentBounds.h > ch)
+        currentBounds.h = std::max(kMinBoxH, ch - currentBounds.y);
+    if (currentBounds.x + currentBounds.w > cw)
+        currentBounds.x = std::max(0, cw - currentBounds.w);
+    if (currentBounds.y + currentBounds.h > ch)
+        currentBounds.y = std::max(0, ch - currentBounds.h);
+    syncDrawCenterFromBounds();
+}
+
+void TextTool::beginEditingWithRect(SDL_Rect box) {
+    currentBounds = box;
+    clampBoundsToCanvas();
+    rotation = 0.f;
+    moved = false;
+    resizing = Handle::NONE;
+    isMoving = false;
+    isRotating = false;
+    flipX = false;
+    flipY = false;
     editing_ = true;
+    buffer.clear();
+    caretByte = 0;
     SDL_StartTextInput();
 }
 
-bool TextTool::onMouseUp(int, int, SDL_Renderer*, int, SDL_Color) {
-    return false;
+void TextTool::stopEditing() {
+    if (!editing_) return;
+    editing_ = false;
+    handleMouseUp();
+    SDL_StopTextInput();
 }
 
-void TextTool::onPreviewRender(SDL_Renderer*, int brushSize, SDL_Color color) {
-    cachedBrushSize = brushSize;
-    cachedColor = color;
+/**
+ * Fills `lines` with half-open byte ranges [first, second) for each visual row, matching greedy word-wrap
+ * used with TTF_RenderUTF8_Blended_Wrapped at the same wrap width.
+ */
+bool TextTool::buildLayoutLines(TTF_Font* font, int wrapPx, std::vector<std::pair<int, int>>& lines) const {
+    lines.clear();
+    wrapPx = std::max(8, wrapPx);
+    const std::string& buf = buffer;
+    const int n = (int)buf.size();
+
+    auto wrapParagraph = [&](int a, int b) {
+        int p = a;
+        while (p < b) {
+            const int lineStart = p;
+            int lastSpaceStart = -1;
+            int lastSpaceEnd = -1;
+            int q = p;
+            while (q < b) {
+                const int cl = utf8CharBytes(buf.c_str() + q);
+                std::string chunk(buf.data() + lineStart, (size_t)(q + cl - lineStart));
+                int tw = 0;
+                if (TTF_SizeUTF8(font, chunk.c_str(), &tw, nullptr) != 0)
+                    break;
+                if (tw > wrapPx) {
+                    if (lastSpaceStart >= lineStart) {
+                        lines.emplace_back(lineStart, lastSpaceEnd);
+                        p = lastSpaceEnd;
+                        goto next_line;
+                    }
+                    if (q == lineStart) {
+                        lines.emplace_back(lineStart, q + cl);
+                        p = q + cl;
+                    } else {
+                        lines.emplace_back(lineStart, q);
+                        p = q;
+                    }
+                    goto next_line;
+                }
+                if (cl == 1 && buf[(size_t)q] == ' ') {
+                    lastSpaceStart = q;
+                    lastSpaceEnd = q + cl;
+                }
+                q += cl;
+            }
+            lines.emplace_back(lineStart, b);
+            p = b;
+        next_line:;
+        }
+    };
+
+    int paraStart = 0;
+    while (paraStart <= n) {
+        int paraEnd = n;
+        for (int i = paraStart; i < n; i++) {
+            if (buf[(size_t)i] == '\n') {
+                paraEnd = i;
+                break;
+            }
+        }
+        if (paraEnd > paraStart)
+            wrapParagraph(paraStart, paraEnd);
+        else if (paraEnd < n && buf[(size_t)paraEnd] == '\n')
+            lines.emplace_back(paraEnd, paraEnd + 1);
+        if (paraEnd >= n)
+            break;
+        paraStart = paraEnd + 1;
+    }
+    if (lines.empty())
+        lines.emplace_back(0, 0);
+    return true;
 }
 
-void TextTool::drawUtf8Line(SDL_Renderer* r, bool forOverlay) {
-    if (!pen_ || buffer.empty()) return;
-
+void TextTool::placeCaretFromCanvas(int cX, int cY) {
     std::string path = pen_->toolbar.currentTextFontPath();
     int pt = pen_->toolbar.textFontPt;
     int style = TTF_STYLE_NORMAL;
     if (pen_->toolbar.textBold) style |= TTF_STYLE_BOLD;
     if (pen_->toolbar.textItalic) style |= TTF_STYLE_ITALIC;
-
     TTF_Font* font = pen_->fontCache_.get(path, pt, style);
     if (!font) return;
 
-    SDL_Color fg = cachedColor;
-    if (forOverlay && fg.a == 0)
-        fg = { 100, 149, 237, 255 };
-    else if (!forOverlay && fg.a != 0)
-        fg.a = 255;
+    const float hw = currentBounds.w * 0.5f, hh = currentBounds.h * 0.5f;
+    float lx, ly;
+    rotatePt((float)cX, (float)cY, drawCenterX, drawCenterY, -getRotation(), lx, ly);
+    const float localX = lx - (drawCenterX - hw);
+    const float localY = ly - (drawCenterY - hh);
 
-    SDL_Surface* surf = nullptr;
-    if (forOverlay || cachedColor.a != 0)
-        surf = TTF_RenderUTF8_Blended(font, buffer.c_str(), fg);
-    else
-        surf = TTF_RenderUTF8_Blended(font, buffer.c_str(), SDL_Color{ 255, 255, 255, 255 });
+    const int wrapPx = std::max(8, currentBounds.w - 2 * kPad);
+    std::vector<std::pair<int, int>> lines;
+    buildLayoutLines(font, wrapPx, lines);
+    const int lineSkip = TTF_FontLineSkip(font);
+    int li = (int)std::floor((localY - kPad) / (float)lineSkip);
+    if (li < 0) li = 0;
+    if (li >= (int)lines.size()) li = (int)lines.size() - 1;
 
-    if (!surf) return;
-    SDL_Texture* tex = SDL_CreateTextureFromSurface(r, surf);
-    SDL_FreeSurface(surf);
-    if (!tex) return;
-
-    if (!forOverlay && cachedColor.a == 0) {
-        SDL_BlendMode eraseBm = eraseGlyphBlendMode();
-        if (SDL_SetTextureBlendMode(tex, eraseBm) != 0)
-            SDL_SetTextureBlendMode(tex, SDL_BLENDMODE_BLEND);
-    } else {
-        SDL_SetTextureBlendMode(tex, SDL_BLENDMODE_BLEND);
+    const int b0 = lines[(size_t)li].first;
+    const int b1 = lines[(size_t)li].second;
+    const float targetX = localX - kPad;
+    if (targetX <= 0) {
+        caretByte = b0;
+        return;
+    }
+    if (b1 <= b0) {
+        caretByte = b0;
+        return;
     }
 
-    int tw = 0, th = 0;
-    SDL_QueryTexture(tex, nullptr, nullptr, &tw, &th);
-    SDL_Rect dst{ anchorX, anchorY, tw, th };
-    SDL_RenderCopy(r, tex, nullptr, &dst);
-    SDL_DestroyTexture(tex);
+    int cp = b0;
+    while (cp < b1) {
+        const int cl = utf8CharBytes(buffer.c_str() + cp);
+        int w = 0;
+        std::string prefix(buffer.data() + b0, (size_t)(cp + cl - b0));
+        if (TTF_SizeUTF8(font, prefix.c_str(), &w, nullptr) != 0)
+            break;
+        if (w > targetX + 2)
+            break;
+        cp += cl;
+    }
+    caretByte = cp;
 }
 
-void TextTool::onOverlayRender(SDL_Renderer* r) {
-    if (!editing_ || !pen_) return;
-    drawUtf8Line(r, true);
+/**
+ * Renders wrapped UTF-8 into an axis-aligned w×h texture, then composites onto the active render target
+ * at the text box position with the current rotation (same idea as ResizeTool::renderShapeAt).
+ */
+void TextTool::renderTextOntoCanvas(SDL_Renderer* r, SDL_Color fg, bool forOverlay) const {
+    if (!pen_ || currentBounds.w <= 0 || currentBounds.h <= 0) return;
 
     std::string path = pen_->toolbar.currentTextFontPath();
     int pt = pen_->toolbar.textFontPt;
@@ -100,32 +223,126 @@ void TextTool::onOverlayRender(SDL_Renderer* r) {
     if (pen_->toolbar.textBold) style |= TTF_STYLE_BOLD;
     if (pen_->toolbar.textItalic) style |= TTF_STYLE_ITALIC;
     TTF_Font* font = pen_->fontCache_.get(path, pt, style);
+    if (!font) return;
 
-    int caretX = anchorX;
-    int caretH = font ? TTF_FontHeight(font) : 14;
-    if (font && !buffer.empty()) {
-        int w = 0;
-        if (TTF_SizeUTF8(font, buffer.c_str(), &w, nullptr) == 0)
-            caretX += w;
+    if (forOverlay && fg.a == 0)
+        fg = {100, 149, 237, 255};
+    else if (!forOverlay && fg.a != 0)
+        fg.a = 255;
+
+    const int w = currentBounds.w, h = currentBounds.h;
+    const int wrapPx = std::max(8, w - 2 * kPad);
+
+    SDL_Surface* textSurf = nullptr;
+    if (buffer.empty()) {
+        textSurf = nullptr;
+    } else if (forOverlay || cachedColor.a != 0)
+        textSurf = TTF_RenderUTF8_Blended_Wrapped(font, buffer.c_str(), fg, wrapPx);
+    else
+        textSurf = TTF_RenderUTF8_Blended_Wrapped(font, buffer.c_str(), SDL_Color{255, 255, 255, 255}, wrapPx);
+
+    SDL_Texture* tmp = SDL_CreateTexture(r, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_TARGET, w, h);
+    if (!tmp) {
+        if (textSurf) SDL_FreeSurface(textSurf);
+        return;
+    }
+    SDL_SetTextureBlendMode(tmp, SDL_BLENDMODE_BLEND);
+    SDL_Texture* prev = SDL_GetRenderTarget(r);
+    SDL_SetRenderTarget(r, tmp);
+    SDL_SetRenderDrawColor(r, 0, 0, 0, 0);
+    SDL_SetRenderDrawBlendMode(r, SDL_BLENDMODE_NONE);
+    SDL_RenderClear(r);
+    SDL_SetRenderDrawBlendMode(r, SDL_BLENDMODE_BLEND);
+
+    if (textSurf) {
+        SDL_Texture* lineTex = SDL_CreateTextureFromSurface(r, textSurf);
+        SDL_FreeSurface(textSurf);
+        if (lineTex) {
+            if (!forOverlay && cachedColor.a == 0) {
+                SDL_BlendMode eraseBm = eraseGlyphBlendMode();
+                if (SDL_SetTextureBlendMode(lineTex, eraseBm) != 0)
+                    SDL_SetTextureBlendMode(lineTex, SDL_BLENDMODE_BLEND);
+            } else
+                SDL_SetTextureBlendMode(lineTex, SDL_BLENDMODE_BLEND);
+            int tw = 0, th = 0;
+            SDL_QueryTexture(lineTex, nullptr, nullptr, &tw, &th);
+            SDL_Rect dst{kPad, kPad, tw, std::min(th, h - 2 * kPad)};
+            SDL_RenderCopy(r, lineTex, nullptr, &dst);
+            SDL_DestroyTexture(lineTex);
+        }
     }
 
-    bool blinkOn = ((SDL_GetTicks() / 530) % 2) == 0;
-    if (blinkOn) {
-        SDL_SetRenderDrawBlendMode(r, SDL_BLENDMODE_BLEND);
-        SDL_Color col = cachedColor;
-        if (col.a == 0)
-            SDL_SetRenderDrawColor(r, 100, 149, 237, 200);
-        else
-            SDL_SetRenderDrawColor(r, col.r, col.g, col.b, 255);
-        int cw = std::max(1, pt / 12);
-        SDL_Rect caret{ caretX, anchorY, cw, std::max(1, caretH) };
-        SDL_RenderFillRect(r, &caret);
+    if (forOverlay) {
+        std::vector<std::pair<int, int>> lines;
+        buildLayoutLines(font, wrapPx, lines);
+        const int lineSkip = TTF_FontLineSkip(font);
+        int li = 0;
+        for (size_t i = 0; i < lines.size(); i++) {
+            const int a = lines[i].first, b = lines[i].second;
+            if (caretByte >= a && caretByte <= b) {
+                li = (int)i;
+                break;
+            }
+            if ((int)i + 1 < (int)lines.size() && caretByte > b && caretByte < lines[i + 1].first)
+                li = (int)i + 1;
+            else if (caretByte > b)
+                li = (int)i;
+        }
+        const int b0 = lines[(size_t)li].first;
+        int caretW = std::max(1, pt / 12);
+        int cx = kPad;
+        if (caretByte > b0 && caretByte <= buffer.size()) {
+            std::string prefix(buffer.data() + b0, (size_t)(caretByte - b0));
+            int cw = 0;
+            if (TTF_SizeUTF8(font, prefix.c_str(), &cw, nullptr) == 0)
+                cx += cw;
+        }
+        const int cy = kPad + li * lineSkip;
+        const int caretH = std::max(1, lineSkip - 2);
+        bool blinkOn = ((SDL_GetTicks() / 530) % 2) == 0;
+        if (blinkOn) {
+            SDL_SetRenderDrawBlendMode(r, SDL_BLENDMODE_BLEND);
+            SDL_SetRenderDrawColor(r, fg.r, fg.g, fg.b, 255);
+            SDL_Rect caret{cx, cy, caretW, caretH};
+            SDL_RenderFillRect(r, &caret);
+        }
     }
+
+    SDL_SetRenderTarget(r, prev);
+
+    const float rot = getRotation();
+    double rotDeg = std::fmod(rot * 180.0 / M_PI, 360.0);
+    if (rotDeg < 0.0) rotDeg += 360.0;
+    const bool parityDiff = (w & 1) != (h & 1);
+    const bool is90or270 = (std::fabs(rotDeg - 90.0) < 1.0 || std::fabs(rotDeg - 270.0) < 1.0);
+    float drawX = getDrawCenterX() - w * 0.5f, drawY = getDrawCenterY() - h * 0.5f;
+    if (is90or270 && parityDiff) {
+        drawX = (float)std::round(drawX);
+        drawY = (float)std::round(drawY);
+    }
+
+    if (rot == 0.f) {
+        SDL_FRect dstF{drawX, drawY, (float)w, (float)h};
+        SDL_RenderCopyF(r, tmp, nullptr, &dstF);
+        SDL_DestroyTexture(tmp);
+        return;
+    }
+
+    float hw = w * 0.5f, hh = h * 0.5f;
+    float pivotX = hw, pivotY = hh;
+    if (is90or270 && parityDiff) {
+        pivotX = (float)std::round(hw);
+        pivotY = (float)std::round(hh);
+    }
+    SDL_FRect dstF = {drawX, drawY, (float)w, (float)h};
+    SDL_FPoint centerF = {pivotX, pivotY};
+    SDL_RenderCopyExF(r, tmp, nullptr, &dstF, rotDeg, &centerF, SDL_FLIP_NONE);
+    SDL_DestroyTexture(tmp);
 }
 
 bool TextTool::stampToCanvas(SDL_Renderer* r) {
     if (buffer.empty()) return false;
-    drawUtf8Line(r, false);
+    renderTextOntoCanvas(r, cachedColor, false);
     return true;
 }
 
@@ -133,17 +350,130 @@ void TextTool::commitEdit(SDL_Renderer* r) {
     if (!editing_) return;
     bool stamped = stampToCanvas(r);
     stopEditing();
+    rotation = 0.f;
+    currentBounds = {0, 0, 0, 0};
     if (stamped && onAfterStamp) onAfterStamp();
 }
 
 void TextTool::discardEdit() {
     if (!editing_) return;
     buffer.clear();
+    caretByte = 0;
     stopEditing();
+    rotation = 0.f;
+    currentBounds = {0, 0, 0, 0};
 }
 
 void TextTool::deactivate(SDL_Renderer* r) {
     commitEdit(r);
+}
+
+void TextTool::onMouseDown(int cX, int cY, SDL_Renderer* r, int brushSize, SDL_Color color) {
+    cachedBrushSize = brushSize;
+    cachedColor = color;
+    if (!isPointOnCanvas(mapper, cX, cY)) return;
+
+    if (editing_) {
+        Handle h = getHandle(cX, cY);
+        if (h != Handle::NONE) {
+            handleMouseDown(cX, cY);
+            return;
+        }
+        if ((SDL_GetModState() & KMOD_ALT) && pointInRotatedBounds(cX, cY)) {
+            handleMouseDown(cX, cY);
+            return;
+        }
+        if (pointInRotatedBounds(cX, cY)) {
+            placeCaretFromCanvas(cX, cY);
+            return;
+        }
+        commitEdit(r);
+    }
+
+    AbstractTool::onMouseDown(cX, cY, r, brushSize, color);
+}
+
+void TextTool::onMouseMove(int cX, int cY, SDL_Renderer* r, int brushSize, SDL_Color color) {
+    cachedBrushSize = brushSize;
+    cachedColor = color;
+    if (isDrawing) {
+        AbstractTool::onMouseMove(cX, cY, r, brushSize, color);
+        return;
+    }
+    if (editing_ && isMutating())
+        handleMouseMove(cX, cY);
+}
+
+bool TextTool::onMouseUp(int cX, int cY, SDL_Renderer* r, int brushSize, SDL_Color color) {
+    if (isDrawing) {
+        int curX = cX, curY = cY;
+        if (SDL_GetModState() & KMOD_SHIFT)
+            applyShiftSquare(startX, startY, curX, curY);
+
+        const bool clickOnly = (curX == startX && curY == startY);
+        SDL_Rect box{};
+        int cw, ch;
+        mapper->getCanvasSize(&cw, &ch);
+
+        if (clickOnly) {
+            int w = std::min(kDefaultBoxW, cw - startX);
+            int h = std::min(kDefaultBoxH, ch - startY);
+            int sx = startX, sy = startY;
+            if (w < kMinBoxW) {
+                sx = std::max(0, std::min(sx, cw - kMinBoxW));
+                w = std::min(kMinBoxW, cw - sx);
+            }
+            if (h < kMinBoxH) {
+                sy = std::max(0, std::min(sy, ch - kMinBoxH));
+                h = std::min(kMinBoxH, ch - sy);
+            }
+            box = {sx, sy, w, h};
+        } else {
+            int minX = std::min(startX, curX), minY = std::min(startY, curY);
+            int dw = std::abs(curX - startX), dh = std::abs(curY - startY);
+            dw = std::max(kMinBoxW, dw);
+            dh = std::max(kMinBoxH, dh);
+            box = {minX, minY, dw, dh};
+        }
+        isDrawing = false;
+        beginEditingWithRect(box);
+        return false;
+    }
+    if (editing_)
+        handleMouseUp();
+    return false;
+}
+
+void TextTool::onPreviewRender(SDL_Renderer* r, int brushSize, SDL_Color color) {
+    cachedBrushSize = brushSize;
+    cachedColor = color;
+    if (isDrawing) {
+        int mouseX, mouseY;
+        SDL_GetMouseState(&mouseX, &mouseY);
+        int curX, curY;
+        mapper->getCanvasCoords(mouseX, mouseY, &curX, &curY);
+        if (curX == startX && curY == startY) return;
+        if (SDL_GetModState() & KMOD_SHIFT)
+            applyShiftSquare(startX, startY, curX, curY);
+        int minX = std::min(startX, curX), minY = std::min(startY, curY);
+        int dw = std::abs(curX - startX), dh = std::abs(curY - startY);
+        int wx0, wy0, wx1, wy1;
+        mapper->getWindowCoords(minX, minY, &wx0, &wy0);
+        mapper->getWindowCoords(minX + dw, minY + dh, &wx1, &wy1);
+        SDL_Rect outline = {wx0, wy0, wx1 - wx0, wy1 - wy0};
+        DrawingUtils::drawMarchingRect(r, &outline);
+        return;
+    }
+    if (editing_)
+        drawHandles(r);
+}
+
+void TextTool::onOverlayRender(SDL_Renderer* r) {
+    if (!pen_) return;
+    if (isDrawing) return;
+    if (!editing_) return;
+    SDL_Color fg = cachedColor;
+    renderTextOntoCanvas(r, fg, true);
 }
 
 bool TextTool::onTextInput(const char* text) {
@@ -151,7 +481,16 @@ bool TextTool::onTextInput(const char* text) {
     bool any = false;
     for (const unsigned char* p = reinterpret_cast<const unsigned char*>(text); *p;) {
         unsigned char c = *p;
-        if (c < 32 && c != '\t') {
+        if (c == '\r') {
+            p++;
+            if ((int)buffer.size() + 1 > kMaxBytes) break;
+            const int ins = std::max(0, std::min(caretByte, (int)buffer.size()));
+            buffer.insert((size_t)ins, "\n");
+            caretByte = ins + 1;
+            any = true;
+            continue;
+        }
+        if (c < 32 && c != '\t' && c != '\n') {
             ++p;
             continue;
         }
@@ -164,9 +503,13 @@ bool TextTool::onTextInput(const char* text) {
             runeLen = 2;
 
         if ((int)buffer.size() + (int)runeLen > kMaxBytes) break;
+        std::string chunk;
         for (size_t i = 0; i < runeLen && p[i]; i++)
-            buffer.push_back(static_cast<char>(p[i]));
+            chunk.push_back(static_cast<char>(p[i]));
         p += runeLen;
+        const int ins = std::max(0, std::min(caretByte, (int)buffer.size()));
+        buffer.insert((size_t)ins, chunk);
+        caretByte = ins + (int)chunk.size();
         any = true;
     }
     return any;
@@ -174,8 +517,26 @@ bool TextTool::onTextInput(const char* text) {
 
 bool TextTool::onKeyDown(SDL_Keycode key) {
     if (!editing_) return false;
+    if (key == SDLK_RETURN || key == SDLK_KP_ENTER) {
+        if ((int)buffer.size() >= kMaxBytes) return true;
+        buffer.push_back('\n');
+        caretByte = (int)buffer.size();
+        return true;
+    }
     if (key == SDLK_BACKSPACE || key == SDLK_DELETE) {
-        utf8PopBack(buffer);
+        if (key == SDLK_BACKSPACE) {
+            if (caretByte <= 0) return true;
+            const int end = caretByte;
+            int i = end - 1;
+            while (i > 0 && ((unsigned char)buffer[(size_t)i] & 0xC0) == 0x80) --i;
+            buffer.erase((size_t)i, (size_t)(end - i));
+            caretByte = i;
+        } else {
+            if (caretByte >= (int)buffer.size()) return true;
+            size_t i = (size_t)caretByte;
+            size_t j = i + (size_t)utf8CharBytes(buffer.c_str() + i);
+            buffer.erase(i, j - i);
+        }
         return true;
     }
     return false;

--- a/src/tools/TextTool.cc
+++ b/src/tools/TextTool.cc
@@ -1,0 +1,201 @@
+#include "Tools.h"
+#include <SDL2/SDL.h>
+#include <algorithm>
+#include <cstdint>
+
+// 5×7 bitmap font (matches toolbar tooltips). Index 0=space, 1–26=A–Z, 27–36=0–9, 37=comma.
+static const uint8_t FONT_5X7[38][7] = {
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 },
+    { 0x04, 0x0A, 0x11, 0x11, 0x1F, 0x11, 0x11 },
+    { 0x1E, 0x11, 0x11, 0x1E, 0x11, 0x11, 0x1E },
+    { 0x0E, 0x11, 0x10, 0x10, 0x10, 0x11, 0x0E },
+    { 0x1E, 0x11, 0x11, 0x11, 0x11, 0x11, 0x1E },
+    { 0x1F, 0x10, 0x10, 0x1E, 0x10, 0x10, 0x1F },
+    { 0x1F, 0x10, 0x10, 0x1E, 0x10, 0x10, 0x10 },
+    { 0x0E, 0x11, 0x10, 0x13, 0x11, 0x11, 0x0F },
+    { 0x11, 0x11, 0x11, 0x1F, 0x11, 0x11, 0x11 },
+    { 0x0E, 0x04, 0x04, 0x04, 0x04, 0x04, 0x0E },
+    { 0x01, 0x01, 0x01, 0x01, 0x11, 0x11, 0x0E },
+    { 0x11, 0x12, 0x14, 0x18, 0x14, 0x12, 0x11 },
+    { 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x1F },
+    { 0x11, 0x1B, 0x15, 0x11, 0x11, 0x11, 0x11 },
+    { 0x11, 0x19, 0x15, 0x13, 0x11, 0x11, 0x11 },
+    { 0x0E, 0x11, 0x11, 0x11, 0x11, 0x11, 0x0E },
+    { 0x1E, 0x11, 0x11, 0x1E, 0x10, 0x10, 0x10 },
+    { 0x0E, 0x11, 0x11, 0x11, 0x15, 0x12, 0x0D },
+    { 0x1E, 0x11, 0x11, 0x1E, 0x14, 0x12, 0x11 },
+    { 0x0F, 0x10, 0x10, 0x0E, 0x01, 0x11, 0x1E },
+    { 0x1F, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04 },
+    { 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x0E },
+    { 0x11, 0x11, 0x11, 0x0A, 0x0A, 0x04, 0x04 },
+    { 0x11, 0x11, 0x11, 0x15, 0x15, 0x1B, 0x11 },
+    { 0x11, 0x11, 0x0A, 0x04, 0x0A, 0x11, 0x11 },
+    { 0x11, 0x11, 0x0A, 0x04, 0x04, 0x04, 0x04 },
+    { 0x1F, 0x01, 0x02, 0x04, 0x08, 0x10, 0x1F },
+    { 0x1F, 0x11, 0x11, 0x11, 0x11, 0x11, 0x1F },
+    { 0x04, 0x0C, 0x04, 0x04, 0x04, 0x04, 0x1F },
+    { 0x1F, 0x01, 0x01, 0x1F, 0x10, 0x10, 0x1F },
+    { 0x1F, 0x01, 0x01, 0x0F, 0x01, 0x01, 0x1F },
+    { 0x11, 0x11, 0x11, 0x1F, 0x01, 0x01, 0x01 },
+    { 0x1F, 0x10, 0x10, 0x1F, 0x01, 0x01, 0x1F },
+    { 0x1F, 0x10, 0x10, 0x1F, 0x11, 0x11, 0x1F },
+    { 0x1F, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01 },
+    { 0x1F, 0x11, 0x11, 0x1F, 0x11, 0x11, 0x1F },
+    { 0x1F, 0x11, 0x11, 0x1F, 0x01, 0x01, 0x1F },
+    { 0x00, 0x00, 0x00, 0x00, 0x04, 0x04, 0x08 },
+};
+
+static int glyphIndex(char c) {
+    if (c == ' ') return 0;
+    if (c == '.' || c == ',') return 37;
+    if (c >= 'A' && c <= 'Z') return 1 + (c - 'A');
+    if (c >= '0' && c <= '9') return 27 + (c - '0');
+    return -1;
+}
+
+static int textScaleForBrush(int brushSize) {
+    return std::max(1, std::min(6, brushSize / 2));
+}
+
+static int glyphAdvance(int scale) { return 5 * scale + scale; }
+
+static int stringWidthPx(const std::string& s, int scale) {
+    int adv = glyphAdvance(scale);
+    int w = 0;
+    for (char c : s) {
+        if (glyphIndex(c) >= 0) w += adv;
+    }
+    return w;
+}
+
+static void drawGlyphPixels(SDL_Renderer* r, int ox, int oy, int gi,
+                            int scale, SDL_Color col) {
+    if (gi < 0 || gi > 37) return;
+    if (col.a == 0) {
+        SDL_SetRenderDrawBlendMode(r, SDL_BLENDMODE_NONE);
+        SDL_SetRenderDrawColor(r, 0, 0, 0, 0);
+    } else {
+        SDL_SetRenderDrawBlendMode(r, SDL_BLENDMODE_BLEND);
+        SDL_SetRenderDrawColor(r, col.r, col.g, col.b, col.a);
+    }
+    for (int row = 0; row < 7; row++) {
+        uint8_t bits = FONT_5X7[gi][row];
+        for (int gx = 0; gx < 5; gx++) {
+            if (bits & (1 << (4 - gx))) {
+                SDL_Rect rect = { ox + gx * scale, oy + row * scale, scale, scale };
+                SDL_RenderFillRect(r, &rect);
+            }
+        }
+    }
+    if (col.a == 0) SDL_SetRenderDrawBlendMode(r, SDL_BLENDMODE_BLEND);
+}
+
+TextTool::TextTool(ICoordinateMapper* m, std::function<void()> onAfterStamp)
+    : AbstractTool(m), onAfterStamp(std::move(onAfterStamp)) {}
+
+void TextTool::stopEditing() {
+    if (!editing_) return;
+    editing_ = false;
+    SDL_StopTextInput();
+}
+
+void TextTool::onMouseDown(int cX, int cY, SDL_Renderer* r, int brushSize, SDL_Color color) {
+    if (!isPointOnCanvas(mapper, cX, cY)) return;
+    cachedBrushSize = brushSize;
+    cachedColor = color;
+    if (editing_) commitEdit(r);
+    anchorX = cX;
+    anchorY = cY;
+    buffer.clear();
+    editing_ = true;
+    SDL_StartTextInput();
+}
+
+bool TextTool::onMouseUp(int, int, SDL_Renderer*, int, SDL_Color) {
+    return false;
+}
+
+void TextTool::onPreviewRender(SDL_Renderer*, int brushSize, SDL_Color color) {
+    cachedBrushSize = brushSize;
+    cachedColor = color;
+}
+
+void TextTool::onOverlayRender(SDL_Renderer* r) {
+    if (!editing_) return;
+    int scale = textScaleForBrush(cachedBrushSize);
+    int x = anchorX;
+    SDL_Color col = cachedColor;
+    for (char ch : buffer) {
+        int gi = glyphIndex(ch);
+        if (gi < 0) continue;
+        drawGlyphPixels(r, x, anchorY, gi, scale, col);
+        x += glyphAdvance(scale);
+    }
+    bool blinkOn = ((SDL_GetTicks() / 530) % 2) == 0;
+    if (blinkOn) {
+        int caretx = anchorX + stringWidthPx(buffer, scale);
+        SDL_SetRenderDrawBlendMode(r, SDL_BLENDMODE_BLEND);
+        if (col.a == 0)
+            SDL_SetRenderDrawColor(r, 100, 149, 237, 200);
+        else
+            SDL_SetRenderDrawColor(r, col.r, col.g, col.b, 255);
+        int ch = 7 * scale;
+        SDL_Rect caret = { caretx, anchorY, std::max(1, scale), ch };
+        SDL_RenderFillRect(r, &caret);
+    }
+}
+
+bool TextTool::stampToCanvas(SDL_Renderer* r) {
+    if (buffer.empty()) return false;
+    int scale = textScaleForBrush(cachedBrushSize);
+    int x = anchorX;
+    for (char ch : buffer) {
+        int gi = glyphIndex(ch);
+        if (gi < 0) continue;
+        drawGlyphPixels(r, x, anchorY, gi, scale, cachedColor);
+        x += glyphAdvance(scale);
+    }
+    return true;
+}
+
+void TextTool::commitEdit(SDL_Renderer* r) {
+    if (!editing_) return;
+    bool stamped = stampToCanvas(r);
+    stopEditing();
+    if (stamped && onAfterStamp) onAfterStamp();
+}
+
+void TextTool::discardEdit() {
+    if (!editing_) return;
+    buffer.clear();
+    stopEditing();
+}
+
+void TextTool::deactivate(SDL_Renderer* r) {
+    commitEdit(r);
+}
+
+bool TextTool::onTextInput(const char* text) {
+    if (!editing_ || !text) return false;
+    bool any = false;
+    for (const unsigned char* p = reinterpret_cast<const unsigned char*>(text); *p; ++p) {
+        unsigned char c = *p;
+        if (c < 32 || c > 126) continue;
+        char ch = static_cast<char>(c);
+        if (ch >= 'a' && ch <= 'z') ch = static_cast<char>(ch - 'a' + 'A');
+        if (glyphIndex(ch) < 0) continue;
+        if ((int)buffer.size() >= kMaxChars) break;
+        buffer.push_back(ch);
+        any = true;
+    }
+    return any;
+}
+
+bool TextTool::onKeyDown(SDL_Keycode key) {
+    if (!editing_) return false;
+    if (key == SDLK_BACKSPACE || key == SDLK_DELETE) {
+        if (!buffer.empty()) buffer.pop_back();
+        return true;
+    }
+    return false;
+}


### PR DESCRIPTION
#3 

## Add text tool

Introduces a Text drawing tool so users can place UTF-8 text on the canvas with system fonts, configurable size (pt), and bold/italic toggles. Fonts are discovered at startup and opened font handles are cached to avoid repeated disk loads. Documentation and build wiring add SDL2_ttf.

### User-facing behavior

- Activate: Text tool from the toolbar (3×3 grid) or `T`
- Place / edit: Click on the canvas to set an anchor and type; text previews on the overlay while editing.
- Commit: Starting a new placement, switching tools, or other flows that deactivate the tool commits the current line to the canvas (with undo integration via `saveState()` after stamp where applicable).
- Style: Toolbar row (when Text is active): prev/next font (cycles scanned `.ttf`/`.otf` list), numeric pt size field (clamped range, editable with SDL text input when focused), Bold and Italic (SDL_ttf style flags).
- Color / eraser: Uses the current brush color; transparent color follows the same erase-style compositing pattern as other tools where implemented.
- Input: `SDL_TEXTINPUT` for characters; Backspace/Delete while editing; logic avoids single-key tool shortcuts stealing keys while typing.
- Brush shortcuts: `,` / `.` for brush size skip adjusting brush when the text pt field is focused (`isTextSizeFieldFocused()`).

### Notes on changed files

- `FontRegistry`: Recursively scans OS font directories (platform-specific) plus the app’s `assets` tree (via `SDL_GetBasePath()`), collects unique canonical paths to `.ttf`/`.otf`, sorted—capped to a max file count / depth.
- `FontCache`: Keys `(path, pixel height, TTF style)`; `TTF_OpenFont` + `TTF_SetFontStyle`; bounded cache with eviction; destructor closes fonts.
- `kPen`: `TTF_Init()` in constructor; `systemFontPaths_` passed to toolbar; `friend class TextTool` so `TextTool` can read private `toolbar` text state and `fontCache_`; `TtfQuitHelper` ensures `TTF_Quit()` runs after `FontCache` releases `TTF_Font*` handles.
- `TextTool`: Holds `kPen*`; implements overlay draw, stamp to canvas, `onTextInput` / `onKeyDown`, buffer limit; coordinates with `kPen` event and resize/paste paths as needed.

### Files (typical set for this feature)

| Purpose | Files |
|------|--------|
| Tool + API | [`src/Tools.h`](src/Tools.h) (`ToolType::TEXT`, `TextTool`), [`src/tools/TextTool.cc`](src/tools/TextTool.cc) |
| App shell | [`src/kPen.h`](src/kPen.h), [`src/kPen.cc`](src/kPen.cc) (init, `setTool`, text events, resize/clipboard interactions) |
| UI | [`src/Toolbar.h`](src/Toolbar.h), [`src/Toolbar.cc`](src/Toolbar.cc) (text row, font list pointer, focus, hit-testing, tooltips) |
| Fonts | [`src/FontCache.h`](src/FontCache.h), [`src/FontCache.cc`](src/FontCache.cc), [`src/FontRegistry.h`](src/FontRegistry.h), [`src/FontRegistry.cc`](src/FontRegistry.cc) |
| Build / docs | [`CMakeLists.txt`](CMakeLists.txt) (`find_package(SDL2_ttf)`, link `SDL2_ttf::…` / PkgConfig), [`README.md`](README.md) (tool row, `T`, deps mention) |

### Testing

- Tested on Linux with updated dependencies